### PR TITLE
hotfix: 변경된 아이콘 경로 재설정

### DIFF
--- a/src/components/atom/Icon/types.ts
+++ b/src/components/atom/Icon/types.ts
@@ -4,7 +4,9 @@ export const ICON_URLS = {
   arrow: '/assets/icons/arrow.svg',
   calendar: '/assets/icons/calendar.svg',
   marker: '/assets/icons/marker.svg',
-  route: '/assets/icons/route.svg'
+  route: '/assets/icons/route.svg',
+  close: '/assets/icons/close.svg',
+  plus: '/assets/icons/plus.svg'
 };
 
 export type IconName = keyof typeof ICON_URLS;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,6 +1,8 @@
 export { default as Header } from './Header';
 export { default as LikeCount } from './LikeCount';
 export { default as BookmarkIcon } from './BookmarkIcon';
+export { default as CloseIcon } from '~/components/domain/course/SelectedArea/CloseIcon';
+export { default as PlusIcon } from '~/components/domain/course/SearchArea/PlusIcon';
 export { default as Form } from './Form';
 export { default as SortFilter } from './SortFilter';
 export { default as CategoryTitle } from './CategoryTitle';

--- a/src/pages/course/create/index.tsx
+++ b/src/pages/course/create/index.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import type { NextPage } from 'next';
 import PlaceMap from '~/components/domain/Map/PlaceMap';
-import CourseMap from '~/components/domain/Map/CourseMap';
 import Head from 'next/head';
 import React, { useEffect, useState } from 'react';
 import { Map, MapMarker, CustomOverlayMap } from 'react-kakao-maps-sdk';
@@ -30,6 +29,7 @@ const CourseCreate: NextPage = () => {
   const [Value, setValue] = useState('');
   const [map, setMap] = useState<kakao.maps.Map>();
   const [markers, setMarkers] = useState<Marker[]>([]);
+
   useEffect(() => {
     if (!map) return;
     console.log(kakao.maps);


### PR DESCRIPTION
# ✅ 이슈번호
closes #40 

# 📌 구현 내역
## 설명
- develop branch에서 CloseIcon과 PlusIcon을 못 불러오는 문제가 있었습니다.
- 조치사항
   - `src/components/atom/Icon/types.ts` 파일에 해당 아이콘에 대한 경로를 추가했습니다.



## 이미지
- before
![image](https://user-images.githubusercontent.com/15838144/182315120-07a344ca-8c68-44ed-a21a-8470b9bcb5cf.png)

- after
![image](https://user-images.githubusercontent.com/15838144/182321729-a1cf6299-262f-4c97-8d9a-e674e303b1e7.png)

