### PR TITLE
feat: 코스 등록 페이지 지역 선택 모달 구현

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,8 +1,8 @@
 export { default as Header } from './Header';
 export { default as LikeCount } from './LikeCount';
 export { default as BookmarkIcon } from './BookmarkIcon';
-export { default as CloseIcon } from '~/components/domain/course/SelectedArea/CloseIcon';
-export { default as PlusIcon } from '~/components/domain/course/SearchArea/PlusIcon';
+export { default as CloseIcon } from '~/components/domain/CourseCreate/SelectedArea/CloseIcon';
+export { default as PlusIcon } from '~/components/domain/CourseCreate/SearchArea/PlusIcon';
 export { default as Form } from './Form';
 export { default as SortFilter } from './SortFilter';
 export { default as CategoryTitle } from './CategoryTitle';

--- a/src/components/domain/CourseCreate/RegionSelect/index.tsx
+++ b/src/components/domain/CourseCreate/RegionSelect/index.tsx
@@ -13,7 +13,7 @@ interface RegionSelectProps {
 const RegionSelect = ({ setRegion, onClose }: RegionSelectProps) => {
   const firstRegionList = ['서울', '인천', '대전', '대구', '광주', '부산', '울산', '세종', '경기'];
   const secondRegionList = ['강원', '충북', '충남', '경북', '경남', '전북', '전남', '제주'];
-  const [beforeRegion, setBeforeRegion] = useState<any>(null);
+  const [beforeRegion, setBeforeRegion] = useState<HTMLButtonElement | null>(null);
   const [isSeleted, setIsSeleted] = useState(false);
   const closeForm = () => {
     Router.back();

--- a/src/components/domain/CourseCreate/RegionSelect/index.tsx
+++ b/src/components/domain/CourseCreate/RegionSelect/index.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import { Dispatch, MouseEvent, SetStateAction, useState } from 'react';
 import { Button, Text } from '~/components/atom';
-import { FONT_COLORS } from '~/utils/constants';
+import { REGIONS, FONT_COLORS } from '~/utils/constants';
+import { Region } from '~/types';
 import theme from '~/styles/theme';
 import CloseIcon from '~/components/domain/CourseCreate/SelectedArea/CloseIcon';
 import Router from 'next/router';
@@ -11,10 +12,9 @@ interface RegionSelectProps {
   onClose?: () => void;
 }
 const RegionSelect = ({ setRegion, onClose }: RegionSelectProps) => {
-  const firstRegionList = ['서울', '인천', '대전', '대구', '광주', '부산', '울산', '세종', '경기'];
-  const secondRegionList = ['강원', '충북', '충남', '경북', '경남', '전북', '전남', '제주'];
   const [beforeRegion, setBeforeRegion] = useState<HTMLButtonElement | null>(null);
   const [isSeleted, setIsSeleted] = useState(false);
+  const regions: Region[] = [...REGIONS];
   const closeForm = () => {
     Router.back();
   };
@@ -33,8 +33,6 @@ const RegionSelect = ({ setRegion, onClose }: RegionSelectProps) => {
   const completeSelect = () => {
     if (onClose && isSeleted) {
       onClose();
-    } else {
-      alert('지역을 선택해주세요!');
     }
   };
   return (
@@ -46,24 +44,34 @@ const RegionSelect = ({ setRegion, onClose }: RegionSelectProps) => {
         </Text>
       </FormHeader>
       <FormBody>
-        {firstRegionList.map((region, index) => {
+        {regions.map((region) => {
+          if (region.text === '강원') {
+            return (
+              <>
+                <br />
+                <br />
+                <RegionButton key={region.text} onClick={regionSelectHandler}>
+                  {region.text}
+                </RegionButton>
+              </>
+            );
+          }
           return (
-            <RegionButton key={index} onClick={regionSelectHandler}>
-              {region}
-            </RegionButton>
-          );
-        })}
-        <br />
-        <br />
-        {secondRegionList.map((region, index) => {
-          return (
-            <RegionButton key={index} onClick={regionSelectHandler}>
-              {region}
+            <RegionButton key={region.text} onClick={regionSelectHandler}>
+              {region.text}
             </RegionButton>
           );
         })}
       </FormBody>
-      <Button onClick={completeSelect}>지역선택완료</Button>
+      <Button
+        disabled={!isSeleted}
+        buttonType="primary"
+        size="lg"
+        fontSize={24}
+        onClick={completeSelect}
+      >
+        지역선택완료
+      </Button>
     </SelectForm>
   );
 };
@@ -71,7 +79,7 @@ const RegionSelect = ({ setRegion, onClose }: RegionSelectProps) => {
 export default RegionSelect;
 
 const SelectForm = styled.div`
-  width: 800px;
+  width: 1000px;
   height: 500px;
   text-align: center;
 `;

--- a/src/components/domain/CourseCreate/RegionSelect/index.tsx
+++ b/src/components/domain/CourseCreate/RegionSelect/index.tsx
@@ -1,0 +1,92 @@
+import styled from '@emotion/styled';
+import { Dispatch, MouseEvent, SetStateAction, useState } from 'react';
+import { Button, Text } from '~/components/atom';
+import { FONT_COLORS } from '~/utils/constants';
+import theme from '~/styles/theme';
+import CloseIcon from '~/components/domain/CourseCreate/SelectedArea/CloseIcon';
+import Router from 'next/router';
+
+interface RegionSelectProps {
+  setRegion: Dispatch<SetStateAction<string>>;
+  onClose?: () => void;
+}
+const RegionSelect = ({ setRegion, onClose }: RegionSelectProps) => {
+  const firstRegionList = ['서울', '인천', '대전', '대구', '광주', '부산', '울산', '세종', '경기'];
+  const secondRegionList = ['강원', '충북', '충남', '경북', '경남', '전북', '전남', '제주'];
+  const [beforeRegion, setBeforeRegion] = useState<any>(null);
+  const [isSeleted, setIsSeleted] = useState(false);
+  const closeForm = () => {
+    Router.back();
+  };
+  const regionSelectHandler = (e: MouseEvent<HTMLButtonElement>) => {
+    setIsSeleted(true);
+    if (beforeRegion !== null) {
+      beforeRegion.style.border = '1px solid white';
+    }
+    if (e.target instanceof HTMLButtonElement) {
+      e.target.style.border = `2px solid ${theme.color.mainColor}`;
+      e.target.style.borderRadius = '20px';
+      setRegion(e.target.innerText);
+      setBeforeRegion(e.target);
+    }
+  };
+  const completeSelect = () => {
+    if (onClose && isSeleted) {
+      onClose();
+    } else {
+      alert('지역을 선택해주세요!');
+    }
+  };
+  return (
+    <SelectForm>
+      <CloseIcon onClick={closeForm} />
+      <FormHeader>
+        <Text size={'xl'} fontWeight={700}>
+          등록하시려는 코스의 지역을 선택해주세요.
+        </Text>
+      </FormHeader>
+      <FormBody>
+        {firstRegionList.map((region, index) => {
+          return (
+            <RegionButton key={index} onClick={regionSelectHandler}>
+              {region}
+            </RegionButton>
+          );
+        })}
+        <br />
+        <br />
+        {secondRegionList.map((region, index) => {
+          return (
+            <RegionButton key={index} onClick={regionSelectHandler}>
+              {region}
+            </RegionButton>
+          );
+        })}
+      </FormBody>
+      <Button onClick={completeSelect}>지역선택완료</Button>
+    </SelectForm>
+  );
+};
+
+export default RegionSelect;
+
+const SelectForm = styled.div`
+  width: 800px;
+  height: 500px;
+  text-align: center;
+`;
+
+const FormHeader = styled.div`
+  padding: 130px 0 60px 0;
+`;
+
+const FormBody = styled.div`
+  padding-bottom: 60px;
+`;
+
+const RegionButton = styled.button`
+  width: 50px;
+  height: 30px;
+  color: ${FONT_COLORS.gray};
+  font-size: 16px;
+`;

--- a/src/components/domain/CourseCreate/SearchArea/PlusIcon.tsx
+++ b/src/components/domain/CourseCreate/SearchArea/PlusIcon.tsx
@@ -2,11 +2,10 @@ import styled from '@emotion/styled';
 import { Icon } from '~/components/atom';
 
 interface PlusIconProps {
-  onClick?: () => void; // 필수로 변경할 예정
+  onClick?: () => void;
 }
 
 const PlusIcon = ({ onClick }: PlusIconProps) => {
-  // todo: 전달받은 onClick 핸들러에서 장소 추가 기능 구현
   return <StyledIcon name="plus" size={12} />;
 };
 

--- a/src/components/domain/CourseCreate/SelectedArea/CloseIcon.tsx
+++ b/src/components/domain/CourseCreate/SelectedArea/CloseIcon.tsx
@@ -2,11 +2,10 @@ import styled from '@emotion/styled';
 import { Icon } from '~/components/atom';
 
 interface CloseIconProps {
-  onClick?: () => void; // 필수로 변경할 예정
+  onClick?: () => void;
 }
 
 const CloseIcon = ({ onClick }: CloseIconProps) => {
-  // todo: 전달받은 onClick 핸들러에서 장소 제거 기능 구현
   return <StyledIcon name="close" size={12} />;
 };
 

--- a/src/pages/course/create/index.tsx
+++ b/src/pages/course/create/index.tsx
@@ -9,9 +9,10 @@ import theme from '~/styles/theme';
 import Button from '~/components/atom/Button';
 import { Icon, Text } from '~/components/atom';
 import SearchAddress from '~/components/domain/Map/SearchAddress';
-import CloseIcon from '~/components/domain/course/SelectedArea/CloseIcon';
-import PlusIcon from '~/components/domain/course/SearchArea/PlusIcon';
-
+import CloseIcon from '~/components/domain/CourseCreate/SelectedArea/CloseIcon';
+import PlusIcon from '~/components/domain/CourseCreate/SearchArea/PlusIcon';
+import Modal from '~/components/atom/Modal';
+import RegionSelect from '~/components/domain/CourseCreate/RegionSelect';
 interface Marker {
   position: {
     lat: number;
@@ -29,6 +30,8 @@ const CourseCreate: NextPage = () => {
   const [Value, setValue] = useState('');
   const [map, setMap] = useState<kakao.maps.Map>();
   const [markers, setMarkers] = useState<Marker[]>([]);
+  const [visible, setVisible] = useState(true);
+  const [region, setRegion] = useState('서울');
 
   useEffect(() => {
     if (!map) return;
@@ -92,12 +95,15 @@ const CourseCreate: NextPage = () => {
       </Head>
 
       <main>
+        <Modal visible={visible} onClose={() => setVisible(visible)}>
+          <RegionSelect setRegion={setRegion} onClose={() => setVisible(false)} />
+        </Modal>
         <CreateWrapper className="landing-page">
           <SelectedArea>
             <SelectedHeader>
               <Icon name="arrow" size={25} rotate={180} />
               <Text size={'xl'} style={{ marginLeft: '40%' }}>
-                제주
+                {visible === false ? region : '서울'}
               </Text>
             </SelectedHeader>
             <SelectedPlace>


### PR DESCRIPTION
# ✅ 이슈번호
closes #42 

# 📌 구현 내역
## 설명
- 코스 등록 페이지 진입 시 생성되는 모달 페이지를 구현했습니다.

case
1. 지역 선택 후 `지역선택완료` 버튼 클릭 시 모달창 닫힌 후 Step1에 지역 데이터 반영
2. 지역 미선택 후 `지역선택완료` 버튼 클릭 시 `지역을 선택해주세요!` alert 호출
3. 우상단 X 아이콘 선택 시 Router.back() 을 호출하여 이전 페이지로 이동 (이 부분은 Icon 컴포넌트에 onClick 추가 반영될때 구현하겠습니다.)

## 이미지
![지역선택 Modal](https://user-images.githubusercontent.com/15838144/182544570-0540e1b9-be82-42f4-a052-c7cff08af96f.gif)


![image](https://user-images.githubusercontent.com/15838144/182543741-c8413092-5410-49f1-a76d-eb1900f6d739.png)
