### PR TITLE
Feature/#26 - 장소 상세페이지 구현

### DIFF
--- a/public/assets/icons/arrow-down.svg
+++ b/public/assets/icons/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="9" viewBox="0 0 17 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.75 1.375L8.5 7.625L15.25 1.375" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/atom/Button/index.tsx
+++ b/src/components/atom/Button/index.tsx
@@ -41,6 +41,7 @@ const Button = ({
       fontSize={fontSize}
       onClick={onClick}
       disabled={disabled}
+      style={style}
       {...props}
     >
       {children}

--- a/src/components/atom/Icon/types.ts
+++ b/src/components/atom/Icon/types.ts
@@ -2,6 +2,7 @@ export const ICON_URLS = {
   heart: '/assets/icons/heart.svg',
   bookmark: '/assets/icons/bookmark.svg',
   arrow: '/assets/icons/arrow.svg',
+  arrowDown: '/assets/icons/arrow-down.svg',
   calendar: '/assets/icons/calendar.svg',
   marker: '/assets/icons/marker.svg',
   route: '/assets/icons/route.svg',

--- a/src/pages/place/detail/[postId].tsx
+++ b/src/pages/place/detail/[postId].tsx
@@ -1,0 +1,159 @@
+import styled from '@emotion/styled';
+import type { NextPageContext } from 'next';
+import Head from 'next/head';
+import React from 'react';
+import { Button, Icon, Image, PageContainer, Text, Title } from '~/components/atom';
+import { CourseList } from '~/components/common';
+import Comment from '~/components/common/Comment';
+import DetailSidebar from '~/components/common/DetailSidebar';
+import theme from '~/styles/theme';
+import { PlacePost } from '~/types';
+
+// DUMMY DATA
+const DUMMY_PLACE_POSTS: PlacePost[] = [
+  {
+    id: 1,
+    name: '도렐 제주본점',
+    addressName: '제주 서귀포시 성산읍 동류암로 20 플레이스 내 LOVE동',
+    roadAddressName: '',
+    latitude: '',
+    longitude: '',
+    category: '',
+    phoneNumber: '010-1234-5678',
+    imageUrl: '',
+    liked: true,
+    bookmarked: true,
+    likeCount: 154,
+    usedCount: 12
+  },
+  {
+    id: 2,
+    name: '꽃돌게장1번가',
+    addressName: '전라남도 여수시 봉산2로 36',
+    roadAddressName: '전라남도 여수시 봉산동 210-2',
+    latitude: '',
+    longitude: '',
+    category: '',
+    phoneNumber: '061-644-0003',
+    imageUrl: '',
+    liked: false,
+    bookmarked: false,
+    likeCount: 99,
+    usedCount: 5
+  }
+];
+
+// DUMMY API
+const getPlacePost = (id: number) => {
+  return new Promise((resolve, reject) => {
+    const data = DUMMY_PLACE_POSTS.find((post) => post.id === id);
+    setTimeout(() => {
+      data ? resolve(data) : reject('error');
+    }, 1000);
+  });
+};
+
+export const getServerSideProps = async (context: NextPageContext) => {
+  const { postId } = context.query;
+  if (!postId || Array.isArray(postId)) {
+    throw new Error('잘못된 요청입니다.');
+  }
+  try {
+    const post = await getPlacePost(parseInt(postId, 10));
+    return {
+      props: { post }
+    };
+  } catch (e) {
+    return {
+      notFound: true
+    };
+  }
+};
+
+interface Props {
+  post: PlacePost;
+}
+
+const PlaceDetailByPostId = ({ post }: Props) => {
+  console.log(post);
+  return (
+    <React.Fragment>
+      <Head>
+        <title>여행할 땐 | 이곳저곳</title>
+        <meta name="description" content="place detail" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <main>
+        <Container type="detail" style={{ position: 'relative' }}>
+          <DetailSidebar
+            likes={post.likeCount}
+            isLiked={post.liked}
+            isBookmarked={post.bookmarked}
+          />
+          <PostHeader>
+            <Title level={1} size="lg" fontWeight={700} block>
+              {post.name}
+            </Title>
+            <UserButtons>
+              <button>수정</button>
+              <button>삭제</button>
+            </UserButtons>
+          </PostHeader>
+          <Text block color="gray">
+            {post.addressName}
+          </Text>
+          <Text size="lg" block>
+            <b style={{ color: `${theme.color.mainColor}` }}>{post.usedCount}개의 여행코스</b>에
+            포함된 장소입니다.
+          </Text>
+          <Button width="140px" style={{ padding: '5px', fontWeight: '500' }}>
+            지도보기 <Icon name="arrowDown" />
+          </Button>
+          <ContentContainer>
+            <Image src="/assets/location/jeju.jpg" alt="여행경로" />
+            <div>어쩌구저쩌구</div>
+          </ContentContainer>
+          <Title level={2} size="sm">
+            이 장소가 포함된 코스
+          </Title>
+          <CourseList />
+          <HorizonDivideLine />
+          <Comment />
+        </Container>
+      </main>
+    </React.Fragment>
+  );
+};
+
+export default PlaceDetailByPostId;
+
+const Container = styled(PageContainer)`
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  margin-top: 40px;
+`;
+
+const PostHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const UserButtons = styled.div`
+  button {
+    color: ${theme.color.fontGray};
+    font-size: 16px;
+    margin-left: 8px;
+  }
+`;
+
+const ContentContainer = styled.section`
+  margin: 20px 0;
+`;
+
+const HorizonDivideLine = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${theme.color.backgroundDarkGray};
+`;

--- a/src/pages/place/detail/index.tsx
+++ b/src/pages/place/detail/index.tsx
@@ -1,17 +1,20 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import React from 'react';
+import { PageContainer } from '~/components/atom';
 
 const PlaceDetail: NextPage = () => {
   return (
     <React.Fragment>
       <Head>
-        <title>우리의 여행코스 | 이곳저곳</title>
-        <meta name="description" content="our travel course" />
+        <title>여행할 땐 | 이곳저곳</title>
+        <meta name="description" content="place detail" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main>PlaceDetail</main>
+      <main>
+        <PageContainer type="detail">여기는 장소 detail 페이지의 홈</PageContainer>
+      </main>
     </React.Fragment>
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,3 +21,19 @@ export type LoginValues = {
 export type Region = {
   text: string;
 };
+
+export type PlacePost = {
+  id: number;
+  name: string;
+  addressName: string;
+  roadAddressName: string;
+  latitude: string;
+  longitude: string;
+  category: string;
+  phoneNumber?: string;
+  imageUrl?: string;
+  liked: boolean;
+  bookmarked: boolean;
+  likeCount: number;
+  usedCount: number;
+};


### PR DESCRIPTION
# ✅ 이슈번호
closes #26 

# 📌 구현 내역
## 설명

1. 장소 상세페이지 (`/place/detail/:postId`) 를 구현했습니다.
2. 더미데이터 2개를 넣어놓았고, 비동기 로직(더미)을 추가해서 없는 post에 접근하면 404 페이지로 가도록 했습니다.
3. 이미 구현된 `<CourseList>` 컴포넌트를 그대로 사용했는데 size가 맞지 않아서 props로 사이즈를 조절할 수 있으면 좋을 것 같습니다.

## 이미지

![place-detail](https://user-images.githubusercontent.com/64957267/182660712-da6dd63d-0d04-4b13-aa42-1cb7a9d873bf.gif)

