### PR TITLE
feat: MyBookmarks 컴포넌트 구현

### DIFF
--- a/src/components/common/CourseList/CourseItem.tsx
+++ b/src/components/common/CourseList/CourseItem.tsx
@@ -3,26 +3,13 @@ import React from 'react';
 import { Link, Text, Title } from '~/components/atom';
 import Avatar from '~/components/atom/Avatar';
 import theme from '~/styles/theme';
+import { ICourseItem } from '~/types/course';
 import BookmarkIcon from '../BookmarkIcon';
 import LikeCount from '../LikeCount';
 
 interface CourseItemProps {
   course?: ICourseItem;
   grid?: number;
-}
-
-export interface ICourseItem {
-  id: number;
-  title: string;
-  thumbnail: string;
-  region: string;
-  period: string;
-  theme: string[];
-  places: string[];
-  likes: number;
-  isBookmarked: boolean;
-  nickname: string;
-  profileUrl: string;
 }
 
 const courseItemData: ICourseItem = {

--- a/src/components/common/CourseList/index.tsx
+++ b/src/components/common/CourseList/index.tsx
@@ -1,95 +1,12 @@
 import styled from '@emotion/styled';
-import CourseItem, { ICourseItem } from './CourseItem';
-
-/*
-  TODO: Props로 courses 데이터 받아서 CourseItem에 전달하도록 구현
-*/
+import { ICourseItem } from '~/types/course';
+import { courseListData } from '~/utils/dummydata';
+import CourseItem from './CourseItem';
 
 interface CourseListProps {
   courses?: ICourseItem[];
   grid?: number;
 }
-
-const courseListData: ICourseItem[] = [
-  {
-    id: 1,
-    title: '[1박 2일] 제주도 여행 추천~ 다들 추천하는 여행지입니다',
-    thumbnail: '/assets/location/course1.jpg',
-    region: '제주',
-    period: '1박 2일',
-    theme: ['혼자여행', '데이트코스'],
-    places: ['인천공항', '도렐제주본점', '서귀포 1번길', '기타'],
-    likes: 12,
-    isBookmarked: false,
-    nickname: 'Jinist',
-    profileUrl: ''
-  },
-  {
-    id: 2,
-    title: '[3박 4일] 경주여행 다녀왔어요~ 힐링하기 좋은 곳 추천!',
-    thumbnail: '/assets/location/course2.jpg',
-    region: '경북',
-    period: '4~7일',
-    theme: ['혼자여행', '드라이브', '힐링'],
-    places: ['황리단길', '첨성대', '대릉원', '경주월드'],
-    likes: 8,
-    isBookmarked: false,
-    nickname: 'Jinist',
-    profileUrl: ''
-  },
-  {
-    id: 3,
-    title: '[2박 3일] 부산 여행코스! 여름엔 부산으로 떠나요!',
-    thumbnail: '/assets/location/course3.PNG',
-    region: '부산',
-    period: '1~3일',
-    theme: ['맛집', '데이트코스', '드라이브', '힐링'],
-    places: ['광안리 해수욕장', '청사포 전망대', '흰여울 문화마을', '김천 문화마을'],
-    likes: 23,
-    isBookmarked: true,
-    nickname: 'Grew',
-    profileUrl: ''
-  },
-  {
-    id: 4,
-    title: '춘천 1박 2일 여행',
-    thumbnail: '/assets/location/course5.jpg',
-    region: '강원',
-    period: '1~3일',
-    theme: ['맛집', '힐링'],
-    places: ['강촌 레일바이크', '제이드가든 수목원', '구곡폭포', '삼악산'],
-    likes: 2,
-    isBookmarked: false,
-    nickname: 'Joe',
-    profileUrl: ''
-  },
-  {
-    id: 5,
-    title: '[4박 5일] 강릉 여행',
-    thumbnail: '/assets/location/course6.PNG',
-    region: '강원',
-    period: '4~5일',
-    theme: ['드라이브', '힐링', '맛집'],
-    places: ['강릉역', '동화가든', '강문해수욕장', '경포호', '택지골수제생갈비', '맘스카롱'],
-    likes: 27,
-    isBookmarked: true,
-    nickname: 'Grew',
-    profileUrl: ''
-  },
-  {
-    id: 6,
-    title: '[1박 2일] 춘천 여행 떠나요',
-    thumbnail: '',
-    region: '강원',
-    period: '1~3일',
-    theme: ['데이트코스', '이쁜카페'],
-    places: ['호반공원', '애니메이션 박물관', '볼트', '레고랜드'],
-    likes: 18,
-    isBookmarked: false,
-    nickname: 'Joe',
-    profileUrl: ''
-  }
-];
 
 const CourseList = ({ courses = courseListData, grid = 3 }: CourseListProps) => {
   return (

--- a/src/components/common/PlaceList/PlaceItem.tsx
+++ b/src/components/common/PlaceList/PlaceItem.tsx
@@ -3,20 +3,19 @@ import { Text, Title } from '~/components/atom';
 import BookmarkIcon from '../BookmarkIcon';
 import LikeCount from '../LikeCount';
 import { IPlaceItem } from '.';
-import { url } from 'inspector';
 
 interface PlaceItemProps {
   place: IPlaceItem;
+  grid: 3 | 4;
 }
 
-const PlaceItem = ({ place }: PlaceItemProps) => {
+const PlaceItem = ({ place, grid }: PlaceItemProps) => {
   const { title, likeCount, usedCount, thumbnail } = place;
   const THUMBNAIL_URL = thumbnail ? thumbnail : '/assets/location/jeju.jpg';
-  console.log(THUMBNAIL_URL);
 
   return (
-    <PlaceContainer>
-      <Thumbnail style={{ backgroundImage: `url(${THUMBNAIL_URL})` }}>
+    <PlaceContainer grid={grid}>
+      <Thumbnail grid={grid} style={{ backgroundImage: `url(${THUMBNAIL_URL})` }}>
         <BookmarkIcon />
       </Thumbnail>
       <PlaceInfo>
@@ -36,13 +35,15 @@ const PlaceItem = ({ place }: PlaceItemProps) => {
 
 export default PlaceItem;
 
-const PlaceContainer = styled.li`
-  width: 274px;
+const PlaceContainer = styled.li<Pick<PlaceItemProps, 'grid'>>`
+  width: ${({ grid }) => (grid === 3 ? '33.3%' : '25%')};
+  padding: 0 10px 40px 10px;
+  box-sizing: border-box;
 `;
 
-const Thumbnail = styled.div`
+const Thumbnail = styled.div<Pick<PlaceItemProps, 'grid'>>`
   width: 100%;
-  height: 195px;
+  height: ${({ grid }) => (grid === 3 ? '215px' : '195px')};
   box-sizing: border-box;
   position: relative;
   background-size: cover;

--- a/src/components/common/PlaceList/PlaceItem.tsx
+++ b/src/components/common/PlaceList/PlaceItem.tsx
@@ -1,54 +1,83 @@
 import styled from '@emotion/styled';
-import { Text, Title } from '~/components/atom';
+import { Link, Text, Title } from '~/components/atom';
 import BookmarkIcon from '../BookmarkIcon';
 import LikeCount from '../LikeCount';
 import { IPlaceItem } from '.';
+import theme from '~/styles/theme';
 
+export type PlaceGrid = 3 | 4;
 interface PlaceItemProps {
   place: IPlaceItem;
-  grid: 3 | 4;
+  grid: PlaceGrid;
 }
 
 const PlaceItem = ({ place, grid }: PlaceItemProps) => {
-  const { title, likeCount, usedCount, thumbnail } = place;
+  const { id, title, likeCount, usedCount, thumbnail } = place;
   const THUMBNAIL_URL = thumbnail ? thumbnail : '/assets/location/jeju.jpg';
 
   return (
     <PlaceContainer grid={grid}>
-      <Thumbnail grid={grid} style={{ backgroundImage: `url(${THUMBNAIL_URL})` }}>
-        <BookmarkIcon />
-      </Thumbnail>
-      <PlaceInfo>
-        <InfoHead>
-          <Title size={16}>{title}</Title>
-          <LikeCount count={likeCount} />
-        </InfoHead>
-        <Description>
-          <Text color="gray" size={15} ellipsis>
-            {usedCount}개의 여행코스에 포함된 장소입니다.
-          </Text>
-        </Description>
-      </PlaceInfo>
+      <Link href={`/place/${id}`}>
+        <ThumbnailWrapper grid={grid}>
+          <Thumbnail
+            className="placeImage"
+            style={{ backgroundImage: `url(${THUMBNAIL_URL})` }}
+          ></Thumbnail>
+          <BookmarkIcon />
+        </ThumbnailWrapper>
+
+        <PlaceInfo>
+          <InfoHead>
+            <Title size={16}>{title}</Title>
+            <LikeCount count={likeCount} />
+          </InfoHead>
+          <Description>
+            <Text color="gray" size={15} ellipsis>
+              {usedCount}개의 여행코스에 포함된 장소입니다.
+            </Text>
+          </Description>
+        </PlaceInfo>
+      </Link>
     </PlaceContainer>
   );
 };
 
 export default PlaceItem;
 
+const { fontGray } = theme.color;
 const PlaceContainer = styled.li<Pick<PlaceItemProps, 'grid'>>`
   width: ${({ grid }) => (grid === 3 ? '33.3%' : '25%')};
   padding: 0 10px 40px 10px;
   box-sizing: border-box;
+  cursor: pointer;
+
+  &:hover .placeImage {
+    transform: scale(1.05);
+  }
+  &:hover .placeImage {
+    color: ${fontGray};
+  }
 `;
 
-const Thumbnail = styled.div<Pick<PlaceItemProps, 'grid'>>`
+const ThumbnailWrapper = styled.div<Pick<PlaceItemProps, 'grid'>>`
   width: 100%;
   height: ${({ grid }) => (grid === 3 ? '215px' : '195px')};
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+`;
+
+const Thumbnail = styled.div`
+  width: 100%;
+  height: 100%;
+
   box-sizing: border-box;
   position: relative;
   background-size: cover;
   border-radius: 8px;
   position: relative;
+  background-size: cover;
+  transition: transform 0.2s;
 `;
 
 const PlaceInfo = styled.div`

--- a/src/components/common/PlaceList/index.tsx
+++ b/src/components/common/PlaceList/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { placeListData } from '~/utils/dummydata';
 import PlaceItem from './PlaceItem';
 
 export interface IPlaceItem {
@@ -11,50 +12,11 @@ export interface IPlaceItem {
   bookmarked: boolean;
 }
 
-const placesData = [
-  {
-    id: 1,
-    title: '도렐 제주본점',
-    likeCount: 2,
-    usedCount: 1,
-    category: '',
-    thumbnail: '/assets/location/place1.jpg',
-    bookmarked: false
-  },
-  {
-    id: 2,
-    title: '레고랜드',
-    likeCount: 2,
-    usedCount: 1,
-    category: '',
-    thumbnail: '/assets/location/course6.PNG',
-    bookmarked: false
-  },
-  {
-    id: 3,
-    title: '대릉원',
-    likeCount: 2,
-    usedCount: 1,
-    category: '',
-    thumbnail: '/assets/location/course2.jpg',
-    bookmarked: false
-  },
-  {
-    id: 4,
-    title: '광안리해수욕장',
-    likeCount: 2,
-    usedCount: 1,
-    category: '',
-    thumbnail: '/assets/location/course5.jpg',
-    bookmarked: false
-  }
-];
-
 interface PlaceListProps {
   places?: IPlaceItem[];
 }
 
-const PlaceList = ({ places = placesData }: PlaceListProps) => {
+const PlaceList = ({ places = placeListData }: PlaceListProps) => {
   return (
     <StyledPlaceList>
       {places.map((place, index) => (

--- a/src/components/common/PlaceList/index.tsx
+++ b/src/components/common/PlaceList/index.tsx
@@ -14,13 +14,14 @@ export interface IPlaceItem {
 
 interface PlaceListProps {
   places?: IPlaceItem[];
+  grid?: 3 | 4;
 }
 
-const PlaceList = ({ places = placeListData }: PlaceListProps) => {
+const PlaceList = ({ grid = 3, places = placeListData }: PlaceListProps) => {
   return (
     <StyledPlaceList>
       {places.map((place, index) => (
-        <PlaceItem key={index} place={place} />
+        <PlaceItem key={index} grid={grid} place={place} />
       ))}
     </StyledPlaceList>
   );
@@ -31,5 +32,6 @@ export default PlaceList;
 const StyledPlaceList = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 40px 20px;
+  margin-right: -10px;
+  margin-left: -10px;
 `;

--- a/src/components/common/PlaceList/index.tsx
+++ b/src/components/common/PlaceList/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { placeListData } from '~/utils/dummydata';
-import PlaceItem from './PlaceItem';
+import PlaceItem, { PlaceGrid } from './PlaceItem';
 
 export interface IPlaceItem {
   id: number;
@@ -14,10 +14,10 @@ export interface IPlaceItem {
 
 interface PlaceListProps {
   places?: IPlaceItem[];
-  grid?: 3 | 4;
+  grid?: PlaceGrid;
 }
 
-const PlaceList = ({ grid = 3, places = placeListData }: PlaceListProps) => {
+const PlaceList = ({ grid = 4, places = placeListData }: PlaceListProps) => {
   return (
     <StyledPlaceList>
       {places.map((place, index) => (

--- a/src/components/domain/UserInfo/MyBookmarks/index.tsx
+++ b/src/components/domain/UserInfo/MyBookmarks/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { CourseList, PlaceList } from '~/components/common';
 import { ICourseItem } from '~/types/course';
 import { IPlaceItem } from '~/types/place';
@@ -12,15 +13,21 @@ interface MyBookmarksProps {
 
 const MyBookmarks = ({ places, courses, onActive, active }: MyBookmarksProps) => {
   return (
-    <Tab onActive={onActive} active={active}>
-      <Tab.item title="여행코스" value="course">
-        <CourseList grid={2} courses={courses} />
-      </Tab.item>
-      <Tab.item title="장소" value="place">
-        <PlaceList places={places} />
-      </Tab.item>
-    </Tab>
+    <Wrapper>
+      <Tab onActive={onActive} active={active} type="radio">
+        <Tab.item title="여행코스" value="course">
+          <CourseList grid={2} courses={courses} />
+        </Tab.item>
+        <Tab.item title="장소" value="place">
+          <PlaceList places={places} />
+        </Tab.item>
+      </Tab>
+    </Wrapper>
   );
 };
 
 export default MyBookmarks;
+
+const Wrapper = styled.div`
+  margin-top: 28px;
+`;

--- a/src/components/domain/UserInfo/MyBookmarks/index.tsx
+++ b/src/components/domain/UserInfo/MyBookmarks/index.tsx
@@ -1,0 +1,26 @@
+import { CourseList, PlaceList } from '~/components/common';
+import { ICourseItem } from '~/types/course';
+import { IPlaceItem } from '~/types/place';
+import Tab from '../Tab';
+
+interface MyBookmarksProps {
+  courses: ICourseItem[];
+  places: IPlaceItem[];
+  onActive: (value: string) => void;
+  active: string;
+}
+
+const MyBookmarks = ({ places, courses, onActive, active }: MyBookmarksProps) => {
+  return (
+    <Tab onActive={onActive} active={active}>
+      <Tab.item title="여행코스" value="course">
+        <CourseList grid={2} courses={courses} />
+      </Tab.item>
+      <Tab.item title="장소" value="place">
+        <PlaceList places={places} />
+      </Tab.item>
+    </Tab>
+  );
+};
+
+export default MyBookmarks;

--- a/src/components/domain/UserInfo/MyBookmarks/index.tsx
+++ b/src/components/domain/UserInfo/MyBookmarks/index.tsx
@@ -19,7 +19,7 @@ const MyBookmarks = ({ places, courses, onActive, active }: MyBookmarksProps) =>
           <CourseList grid={2} courses={courses} />
         </Tab.item>
         <Tab.item title="장소" value="place">
-          <PlaceList places={places} />
+          <PlaceList grid={3} places={places} />
         </Tab.item>
       </Tab>
     </Wrapper>

--- a/src/components/domain/UserInfo/ProfileCard/index.tsx
+++ b/src/components/domain/UserInfo/ProfileCard/index.tsx
@@ -11,6 +11,7 @@ interface ProfileCardProps {
   postCount: number;
   bookmarkCount: number;
   commentCount: number;
+  isMyPage: boolean;
 }
 
 const ProfileCard = ({
@@ -20,16 +21,19 @@ const ProfileCard = ({
   onClickAction,
   postCount,
   bookmarkCount,
-  commentCount
+  commentCount,
+  isMyPage
 }: ProfileCardProps) => {
   return (
     <Container>
       <UserProfile>
         <ProfileImage>
           <ProfileAvatar size={143} src={profileImage} />
-          <EditButton>
-            <Icon size={16} name="pencil" block />
-          </EditButton>
+          {isMyPage && (
+            <EditButton>
+              <Icon size={16} name="pencil" block />
+            </EditButton>
+          )}
         </ProfileImage>
         <ProfileInfo>
           <Title block>{nickname}</Title>
@@ -56,18 +60,20 @@ const ProfileCard = ({
           </Text.Button>
         </li>
       </UserActions>
-      <InfoEdit>
-        <li>
-          <Link href="/userinfo/edit">
-            <Text>내 정보 변경</Text>
-          </Link>
-        </li>
-        <li>
-          <Link href="/userinfo/password">
-            <Text>비밀번호 변경</Text>
-          </Link>
-        </li>
-      </InfoEdit>
+      {isMyPage && (
+        <InfoEdit>
+          <li>
+            <Link href="/userinfo/edit">
+              <Text>내 정보 변경</Text>
+            </Link>
+          </li>
+          <li>
+            <Link href="/userinfo/password">
+              <Text>비밀번호 변경</Text>
+            </Link>
+          </li>
+        </InfoEdit>
+      )}
     </Container>
   );
 };
@@ -114,10 +120,6 @@ const EditButton = styled.button`
 `;
 
 const UserActions = styled.ul`
-  padding-bottom: 24px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid ${borderGray};
-
   li {
     display: flex;
     justify-content: space-between;
@@ -128,7 +130,11 @@ const ProfileInfo = styled.div`
   margin-top: 18px;
   text-align: center;
 `;
+
 const InfoEdit = styled.div`
+  border-top: 1px solid ${borderGray};
+  margin-top: 24px;
+  padding-top: 24px;
   li {
     padding: 10px 0;
   }

--- a/src/components/domain/UserInfo/Tab/TabItem.tsx
+++ b/src/components/domain/UserInfo/Tab/TabItem.tsx
@@ -8,12 +8,14 @@ interface TabItemProps {
   children: ReactNode;
   value: string;
   active?: boolean;
+  type?: 'tab' | 'radio';
   onClick?: () => void;
 }
-const TabItem = ({ title, active, onClick, ...props }: TabItemProps) => {
+const TabItem = ({ title, active, type, onClick, ...props }: TabItemProps) => {
   return (
-    <TabItemWrapper active={active} onClick={onClick} {...props}>
+    <TabItemWrapper active={active} type={type} onClick={onClick} {...props}>
       <Text color={active ? 'main' : 'dark'} size="lg" fontWeight={active ? 700 : 500}>
+        {type === 'radio' && '· '}
         {title}
       </Text>
     </TabItemWrapper>
@@ -24,12 +26,12 @@ export default TabItem;
 
 const { mainColor } = theme.color;
 
-const TabItemWrapper = styled.div<Pick<TabItemProps, 'active'>>`
+const TabItemWrapper = styled.div<{ active?: boolean; type?: 'tab' | 'radio' }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 0;
-  ${({ active }) => active && `border-bottom: 2px solid ${mainColor} `};
+  padding: 10px 0 18px;
+  ${({ active, type }) => type === 'tab' && active && `border-bottom: 2px solid ${mainColor} `};
   margin-right: 28px;
   cursor: pointer;
 `;

--- a/src/components/domain/UserInfo/Tab/index.tsx
+++ b/src/components/domain/UserInfo/Tab/index.tsx
@@ -6,9 +6,10 @@ interface TabProps {
   children: ReactNode;
   onActive: (value: string) => void;
   active?: string;
+  type?: 'tab' | 'radio';
 }
 
-const Tab = ({ children, active, onActive, ...props }: TabProps) => {
+const Tab = ({ children, active, onActive, type = 'tab', ...props }: TabProps) => {
   const childrenArray = React.Children.toArray(children);
 
   const items = useMemo(() => {
@@ -18,13 +19,14 @@ const Tab = ({ children, active, onActive, ...props }: TabProps) => {
           ...element.props,
           key: element.props.value,
           active: element.props.value === active,
+          type: type,
           onClick: () => {
             onActive(element.props.value);
           }
         });
       }
     });
-  }, [childrenArray, active, onActive]);
+  }, [childrenArray, active, onActive, type]);
 
   const activeItem = useMemo(() => {
     return items.find((element) => active === element?.props.value);
@@ -32,7 +34,7 @@ const Tab = ({ children, active, onActive, ...props }: TabProps) => {
 
   return (
     <div {...props}>
-      <TabItemContainer>{items}</TabItemContainer>
+      <TabItemContainer type={type}>{items}</TabItemContainer>
       <TabItemContent>{activeItem?.props.children}</TabItemContent>
     </div>
   );
@@ -42,8 +44,9 @@ Tab.item = TabItem;
 
 export default Tab;
 
-const TabItemContainer = styled.div`
+const TabItemContainer = styled.div<Pick<TabProps, 'type'>>`
   display: flex;
+  border-bottom: ${({ type }) => type === 'tab' && ' 1px solid #dfdfdf;'};
 `;
 
 const TabItemContent = styled.div`

--- a/src/pages/userinfo/[id]/index.tsx
+++ b/src/pages/userinfo/[id]/index.tsx
@@ -4,11 +4,12 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { PageContainer } from '~/components/atom';
-import { CourseList } from '~/components/common';
+import { CourseList, PlaceList } from '~/components/common';
+import MyBookmarks from '~/components/domain/UserInfo/MyBookmarks';
 import MyComments from '~/components/domain/UserInfo/MyComments';
 import ProfileCard from '~/components/domain/UserInfo/ProfileCard';
 import Tab from '~/components/domain/UserInfo/Tab';
-import { courseListData } from '~/utils/dummydata';
+import { courseListData, placeListData } from '~/utils/dummydata';
 
 export type IComment = {
   id: number;
@@ -42,6 +43,7 @@ const courseCommentData = [
 
 const Userinfo: NextPage = () => {
   const [ActiveMenu, setActiveMenu] = useState('post');
+  const [ActiveBookmark, setActiveBookmark] = useState('course');
   const router = useRouter();
 
   const currentUserId = 1; // 전역데이터라고 가정
@@ -49,6 +51,10 @@ const Userinfo: NextPage = () => {
 
   const onClickAction = (value: string) => {
     setActiveMenu(value);
+  };
+
+  const onClickBookmarkTab = (value: string) => {
+    setActiveBookmark(value);
   };
 
   return (
@@ -79,7 +85,12 @@ const Userinfo: NextPage = () => {
                     <CourseList grid={2} courses={courseListData} />
                   </Tab.item>
                   <Tab.item title="북마크" value="bookmark">
-                    <CourseList grid={2} courses={courseListData} />
+                    <MyBookmarks
+                      courses={courseListData}
+                      places={placeListData}
+                      onActive={onClickBookmarkTab}
+                      active={ActiveBookmark}
+                    />
                   </Tab.item>
                   {isMyPage && (
                     <Tab.item title="댓글" value="comment">

--- a/src/pages/userinfo/[id]/index.tsx
+++ b/src/pages/userinfo/[id]/index.tsx
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 import type { NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { PageContainer } from '~/components/atom';
 import { CourseList } from '~/components/common';
 import MyComments from '~/components/domain/UserInfo/MyComments';
 import ProfileCard from '~/components/domain/UserInfo/ProfileCard';
 import Tab from '~/components/domain/UserInfo/Tab';
+import { courseListData } from '~/utils/dummydata';
 
 export type IComment = {
   id: number;
@@ -22,7 +24,7 @@ export type IComment = {
   };
 };
 
-const dummyComment = [
+const courseCommentData = [
   {
     id: 1,
     rootId: '2',
@@ -40,6 +42,10 @@ const dummyComment = [
 
 const Userinfo: NextPage = () => {
   const [ActiveMenu, setActiveMenu] = useState('post');
+  const router = useRouter();
+
+  const currentUserId = 1; // 전역데이터라고 가정
+  const isMyPage = Number(router.query.id) === currentUserId;
 
   const onClickAction = (value: string) => {
     setActiveMenu(value);
@@ -64,19 +70,22 @@ const Userinfo: NextPage = () => {
               postCount={1}
               bookmarkCount={2}
               commentCount={3}
+              isMyPage={isMyPage}
             />
             <ActionContent>
               <ul>
                 <Tab onActive={onClickAction} active={ActiveMenu}>
                   <Tab.item title="게시물" value="post">
-                    <CourseList grid={2} />
+                    <CourseList grid={2} courses={courseListData} />
                   </Tab.item>
                   <Tab.item title="북마크" value="bookmark">
-                    <CourseList grid={2} />
+                    <CourseList grid={2} courses={courseListData} />
                   </Tab.item>
-                  <Tab.item title="댓글" value="comment">
-                    <MyComments comments={dummyComment} />
-                  </Tab.item>
+                  {isMyPage && (
+                    <Tab.item title="댓글" value="comment">
+                      <MyComments comments={courseCommentData} />
+                    </Tab.item>
+                  )}
                 </Tab>
               </ul>
               <div></div>

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,0 +1,13 @@
+export interface ICourseItem {
+  id: number;
+  title: string;
+  thumbnail: string;
+  region: string;
+  period: string;
+  theme: string[];
+  places: string[];
+  likes: number;
+  isBookmarked: boolean;
+  nickname: string;
+  profileUrl: string;
+}

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -1,0 +1,9 @@
+export interface IPlaceItem {
+  id: number;
+  title: string;
+  likeCount: number;
+  usedCount: number;
+  category: string;
+  thumbnail: string;
+  bookmarked: boolean;
+}

--- a/src/utils/dummydata.ts
+++ b/src/utils/dummydata.ts
@@ -80,3 +80,42 @@ export const courseListData: ICourseItem[] = [
     profileUrl: ''
   }
 ];
+
+export const placeListData = [
+  {
+    id: 1,
+    title: '도렐 제주본점',
+    likeCount: 2,
+    usedCount: 1,
+    category: '',
+    thumbnail: '/assets/location/place1.jpg',
+    bookmarked: false
+  },
+  {
+    id: 2,
+    title: '레고랜드',
+    likeCount: 2,
+    usedCount: 1,
+    category: '',
+    thumbnail: '/assets/location/course6.PNG',
+    bookmarked: false
+  },
+  {
+    id: 3,
+    title: '대릉원',
+    likeCount: 2,
+    usedCount: 1,
+    category: '',
+    thumbnail: '/assets/location/course2.jpg',
+    bookmarked: false
+  },
+  {
+    id: 4,
+    title: '광안리해수욕장',
+    likeCount: 2,
+    usedCount: 1,
+    category: '',
+    thumbnail: '/assets/location/course5.jpg',
+    bookmarked: false
+  }
+];

--- a/src/utils/dummydata.ts
+++ b/src/utils/dummydata.ts
@@ -1,0 +1,82 @@
+import { ICourseItem } from '~/types/course';
+
+export const courseListData: ICourseItem[] = [
+  {
+    id: 1,
+    title: '[1박 2일] 제주도 여행 추천~ 다들 추천하는 여행지입니다',
+    thumbnail: '/assets/location/course1.jpg',
+    region: '제주',
+    period: '1박 2일',
+    theme: ['혼자여행', '데이트코스'],
+    places: ['인천공항', '도렐제주본점', '서귀포 1번길', '기타'],
+    likes: 12,
+    isBookmarked: false,
+    nickname: 'Jinist',
+    profileUrl: ''
+  },
+  {
+    id: 2,
+    title: '[3박 4일] 경주여행 다녀왔어요~ 힐링하기 좋은 곳 추천!',
+    thumbnail: '/assets/location/course2.jpg',
+    region: '경북',
+    period: '4~7일',
+    theme: ['혼자여행', '드라이브', '힐링'],
+    places: ['황리단길', '첨성대', '대릉원', '경주월드'],
+    likes: 8,
+    isBookmarked: false,
+    nickname: 'Jinist',
+    profileUrl: ''
+  },
+  {
+    id: 3,
+    title: '[2박 3일] 부산 여행코스! 여름엔 부산으로 떠나요!',
+    thumbnail: '/assets/location/course3.PNG',
+    region: '부산',
+    period: '1~3일',
+    theme: ['맛집', '데이트코스', '드라이브', '힐링'],
+    places: ['광안리 해수욕장', '청사포 전망대', '흰여울 문화마을', '김천 문화마을'],
+    likes: 23,
+    isBookmarked: true,
+    nickname: 'Grew',
+    profileUrl: ''
+  },
+  {
+    id: 4,
+    title: '춘천 1박 2일 여행',
+    thumbnail: '/assets/location/course5.jpg',
+    region: '강원',
+    period: '1~3일',
+    theme: ['맛집', '힐링'],
+    places: ['강촌 레일바이크', '제이드가든 수목원', '구곡폭포', '삼악산'],
+    likes: 2,
+    isBookmarked: false,
+    nickname: 'Joe',
+    profileUrl: ''
+  },
+  {
+    id: 5,
+    title: '[4박 5일] 강릉 여행',
+    thumbnail: '/assets/location/course6.PNG',
+    region: '강원',
+    period: '4~5일',
+    theme: ['드라이브', '힐링', '맛집'],
+    places: ['강릉역', '동화가든', '강문해수욕장', '경포호', '택지골수제생갈비', '맘스카롱'],
+    likes: 27,
+    isBookmarked: true,
+    nickname: 'Grew',
+    profileUrl: ''
+  },
+  {
+    id: 6,
+    title: '[1박 2일] 춘천 여행 떠나요',
+    thumbnail: '',
+    region: '강원',
+    period: '1~3일',
+    theme: ['데이트코스', '이쁜카페'],
+    places: ['호반공원', '애니메이션 박물관', '볼트', '레고랜드'],
+    likes: 18,
+    isBookmarked: false,
+    nickname: 'Joe',
+    profileUrl: ''
+  }
+];


### PR DESCRIPTION
# ✅ 이슈번호
closes #80 

# 📌 구현 내역

## MyBookmarks 컴포넌트 구현
- 유저 페이지의 북마크 탭 클릭 시 여행코스와 장소를 따로 분리해서 확인할 수 있도록 변경하였습니다
- 유저 정보 페이지에 더미데이터로 본인페이지와 타인페이지를 구분할 수 있게 로직을 작성해두었습니다.

## PlaceItem grid props 추가
- PlaceItem도 외부 컨테이너로 size를 조절할 수 있게 px이 아닌 %로 구현하고 grid props를 추가했습니다.
![image](https://user-images.githubusercontent.com/81489300/182941923-da4c1536-21b7-46b8-8f61-b035fcfd94a0.png)
- PlaceItem도 courseItem과 마찬가지로 hover style 및 link 연결 추가했습니다.

## 구현 이미지
![placeItem2](https://user-images.githubusercontent.com/81489300/182942546-aa793226-4d78-4f83-afc6-ee01b9a8848b.gif)

