### PR TITLE
feat: 회원가입 성공 시 로그인 화면으로 전환, 이메일/닉네임 중복체크 기능 추가

### DIFF
--- a/src/components/domain/SignupForm/Fields/EmailField.tsx
+++ b/src/components/domain/SignupForm/Fields/EmailField.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { Button, Input, Label } from '~/components/atom';
 import { ErrorMessage, Field } from '~/components/common';
+import { UserApi } from '~/service';
 import { FONT_SIZES } from '~/utils/constants';
 
 interface EmailFieldProps {
@@ -38,11 +39,12 @@ const EmailField: React.FC<EmailFieldProps> = ({
     if (disabled) {
       return;
     }
-    //TODO
-    // 1. 이메일 중복확인 로직 추가
-    // 2. 응답에 따라 ConfirmModal 불러오기
-    if (window.confirm(`${value}는 사용가능한 메일입니다!`)) {
+    try {
+      await UserApi.emailCheck({ email: value });
+      window.alert(`${value}는 사용가능한 메일입니다!`);
       setDuplicateCheckFn();
+    } catch (e) {
+      window.alert('이미 존재하는 메일이에요!');
     }
   };
 

--- a/src/components/domain/SignupForm/Fields/NicknameField.tsx
+++ b/src/components/domain/SignupForm/Fields/NicknameField.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import React, { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { Button, Input, Label, Text } from '~/components/atom';
 import { ErrorMessage, Field } from '~/components/common';
-import theme from '~/styles/theme';
+import { UserApi } from '~/service';
 
 interface NicknameFieldProps {
   value: string;
@@ -37,15 +37,14 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
 
   const handleClickDuplicate = async () => {
     if (disabled) {
-      //TODO
-      // error가 있으면 중복확인버튼을 disable
       return;
     }
-    //TODO
-    // 1. 이메일 중복확인 로직 추가
-    // 2. 응답에 따라 ConfirmModal 불러오기
-    if (!error && window.confirm(`${value}는 사용가능한 닉네임입니다!`)) {
+    try {
+      await UserApi.nicknameCheck({ nickname: value });
+      window.alert(`${value}는 사용가능한 닉네임입니다!`);
       setDuplicateCheckFn();
+    } catch (e) {
+      window.alert('이미 존재하는 닉네임이에요!');
     }
   };
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,15 +1,23 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import React from 'react';
 import { SignupForm } from '~/components/domain';
 import { UserApi } from '~/service';
 import { SignupValues } from '~/types';
 
 const Signup: NextPage = () => {
+  const router = useRouter();
+
   const handleSubmit = async (data: SignupValues) => {
-    console.log('회원가입 시도!', data);
+    // TODO
+    // 회원가입 실패 시 로직 추가해야함
     const response = await UserApi.signup(data);
-    console.log(`회원가입 성공!`, response);
+    if (response.nickname === data.nickname) {
+      if (window.confirm(`${response.nickname}님 환영합니다! 로그인하러 갈까요?`)) {
+        router.push('/login');
+      }
+    }
   };
 
   return (

--- a/src/service/core/WebStorage.ts
+++ b/src/service/core/WebStorage.ts
@@ -3,15 +3,14 @@ type TokenKey = 'jwt-token';
 export default class WebStorage {
   private static readonly tokenKey: TokenKey = 'jwt-token';
 
-  static getToken(): string | null {
+  static getToken(): string | void {
     if (typeof window !== 'undefined') {
       const value = window.localStorage.getItem(this.tokenKey);
       if (value) {
         return JSON.parse(value);
       }
-      return null;
+      this.removeToken();
     }
-    return null;
   }
 
   static setToken(token: string): void {

--- a/src/service/domains/user.ts
+++ b/src/service/domains/user.ts
@@ -21,6 +21,16 @@ class UserApi extends Api {
       console.error(`회원가입 에러:`, e);
     }
   };
+
+  emailCheck = async (bodyData: { email: string }) => {
+    const response = await this.baseInstance.post(`${this.path}/email`, bodyData);
+    return response;
+  };
+
+  nicknameCheck = async (bodyData: { nickname: string }) => {
+    const response = await this.baseInstance.post(`${this.path}/nickname`, bodyData);
+    return response;
+  };
 }
 
 export default new UserApi();


### PR DESCRIPTION
# ✅ 이슈번호
closes #85 

# 📌 구현 내역
## 설명

1. 회원가입 성공 시 로그인화면으로 보내는 알림을 추가했습니다.
2. 이메일/닉네임 중복체크하는 api를 연결했습니다.

## 이미지

![signup](https://user-images.githubusercontent.com/64957267/183014903-8bee8b64-1d47-41ea-a3c7-e71c43e3356c.gif)

