### PR TITLE
fix: CourseMap 컴포넌트 Props 및 내부 로직 수정

### DIFF
--- a/src/components/domain/Map/CourseMap/index.tsx
+++ b/src/components/domain/Map/CourseMap/index.tsx
@@ -4,10 +4,32 @@ import markerIcon from 'public/assets/place/course.png';
 import Script from 'next/script';
 import styled from '@emotion/styled';
 
-type CourseType = { placeId: number; lat: number; lng: number; placeName: string };
+interface IPlace {
+  id: number;
+  name: string;
+  description: string;
+  address: string;
+  latitude: string;
+  longitude: string;
+  category: string;
+  phone: string;
+  recommended: boolean;
+}
+interface CourseType {
+  id: number;
+  latitude: string;
+  longitude: string;
+  name: string;
+}
 
+interface PolyLineCourse {
+  placeId: number;
+  lat: number;
+  lng: number;
+  placeName: string;
+}
 interface CourseMapProps {
-  course: CourseType[];
+  course: CourseType[] | IPlace[];
 }
 let isAlreadyLoaded = false;
 const CourseMap = ({ course }: CourseMapProps) => {
@@ -22,7 +44,7 @@ const CourseMap = ({ course }: CourseMapProps) => {
       const bounds = new kakao.maps.LatLngBounds();
 
       course.forEach((place) => {
-        bounds.extend(new kakao.maps.LatLng(place.lat, place.lng));
+        bounds.extend(new kakao.maps.LatLng(Number(place.latitude), Number(place.longitude)));
       });
       const map = mapState;
       if (map) {
@@ -30,7 +52,14 @@ const CourseMap = ({ course }: CourseMapProps) => {
       }
     }
   }, [mapState]);
-
+  const polyLineCourse = course.map((place) => {
+    return {
+      placeId: place.id,
+      lat: Number(place.latitude),
+      lng: Number(place.longitude),
+      placeName: place.name
+    } as PolyLineCourse;
+  });
   return (
     <>
       <Script
@@ -57,7 +86,7 @@ const CourseMap = ({ course }: CourseMapProps) => {
           {course.map((place, index) => (
             <React.Fragment key={index}>
               <MapMarker
-                position={{ lat: place.lat, lng: place.lng }}
+                position={{ lat: Number(place.latitude), lng: Number(place.longitude) }}
                 image={{
                   src: markerIcon.src,
                   size: {
@@ -73,7 +102,7 @@ const CourseMap = ({ course }: CourseMapProps) => {
                 }}
               ></MapMarker>
               <CustomOverlayMap
-                position={{ lat: place.lat, lng: place.lng }}
+                position={{ lat: Number(place.latitude), lng: Number(place.longitude) }}
                 xAnchor={0}
                 yAnchor={1.1}
                 clickable={true}
@@ -81,18 +110,18 @@ const CourseMap = ({ course }: CourseMapProps) => {
                 <span>{index + 1}</span>
                 <MarkerWithCustomOverlayStyle>
                   <a
-                    href={`https://map.kakao.com/link/map/${place.placeId}`}
+                    href={`https://map.kakao.com/link/map/${place.id}`}
                     target="_blank"
                     rel="noreferrer"
                   >
-                    <span>{place.placeName}</span>
+                    <span>{place.name}</span>
                   </a>
                 </MarkerWithCustomOverlayStyle>
               </CustomOverlayMap>
             </React.Fragment>
           ))}
           <Polyline
-            path={course}
+            path={polyLineCourse}
             strokeWeight={5}
             strokeColor={'#FF5F5F'}
             strokeOpacity={0.9}

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -167,7 +167,7 @@ const CourseDetail: NextPage = () => {
               <DetailTitle size="md" fontWeight={700}>
                 여행경로
               </DetailTitle>
-              <CourseMap course={courseMapData} />
+              <CourseMap course={courseData.places} />
             </TravelRoute>
             <TravelCourse>
               <DetailTitle size="md" fontWeight={700}>

--- a/src/pages/course/create/step2/index.tsx
+++ b/src/pages/course/create/step2/index.tsx
@@ -13,6 +13,13 @@ import { useRouter } from 'next/router';
 import { CourseApi } from '~/service';
 import { SearchTagsValues } from '~/types';
 
+interface CourseType {
+  id: number;
+  latitude: string;
+  longitude: string;
+  name: string;
+}
+
 type PlaceType = {
   id: number;
   lat: number;
@@ -72,11 +79,11 @@ const Course: NextPage = () => {
 
   const courseMapData = courseInfo.places.map((place) => {
     return {
-      placeId: place.id,
-      lat: place.lat,
-      lng: place.lng,
-      placeName: place.name
-    };
+      id: place.id,
+      latitude: place.lat,
+      longitude: place.lng,
+      name: place.name
+    } as unknown as CourseType;
   });
   const placesFormDataSetter = () => {
     return courseInfo.places.map((place, index) => {


### PR DESCRIPTION
# ✅ 이슈번호
closes #99 

# 📌 구현 내역
## 설명
- 전달받는 course 객체 배열의 키값 백엔드 API와 통일
![image](https://user-images.githubusercontent.com/15838144/183257525-89b77d16-772d-4836-bd2f-7f589a81c9b9.png)

- IPlace type Guard 추가
![image](https://user-images.githubusercontent.com/15838144/183257509-71acd340-0e24-4d0e-b1a0-2e5f8154c597.png)

- 전달 받는 위도, 경도 type 모두 string으로 통일 후 CourseMap 컴포넌트에서 string to number 처리
![image](https://user-images.githubusercontent.com/15838144/183257577-caa493a8-ebb9-4b13-947f-ecb8f805b111.png)

