### PR TITLE
feat: 검색기능 구현

### DIFF
--- a/src/components/common/SelectRegion/index.tsx
+++ b/src/components/common/SelectRegion/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import theme from '~/styles/theme';
 import { RegionAndAll } from '~/types';
 import { REGIONS } from '~/utils/constants';
@@ -8,16 +8,22 @@ import RegionItem from './RegionItem';
 interface SelectRegionProps {
   col?: number;
   onSelect: (region: RegionAndAll) => void;
+  toInitializeTrigger?: string | number | boolean | null | undefined;
 }
 
 const regions: RegionAndAll[] = ['전체보기', ...REGIONS];
 
-const SelectRegion = ({ onSelect, col = 9 }: SelectRegionProps) => {
+const SelectRegion = ({ onSelect, col = 9, toInitializeTrigger }: SelectRegionProps) => {
   const [selectedValue, setSelectedValue] = useState(regions[0]);
+  const initialize = () => setSelectedValue(regions[0]);
   const handleSelect = (region: RegionAndAll) => {
     setSelectedValue(region);
     onSelect && onSelect(region);
   };
+
+  useEffect(() => {
+    initialize();
+  }, [toInitializeTrigger]);
 
   return (
     <GridContainer col={col}>

--- a/src/components/common/SelectTags/index.tsx
+++ b/src/components/common/SelectTags/index.tsx
@@ -9,12 +9,22 @@ import ThemeTags from './ThemeTags';
 interface SelectTagsProps {
   style?: CSSProperties;
   onSelect: (data: SearchTagsValues) => void;
+  toInitializeTrigger?: string | number | boolean | null | undefined;
 }
 
-const SelectTags = ({ style, onSelect }: SelectTagsProps) => {
+const SelectTags = ({ style, onSelect, toInitializeTrigger }: SelectTagsProps) => {
   const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null);
   const [selectedThemes, setSelectedThemes] = useState<Theme[]>([]);
   const [selectedSpots, setSelectedSpots] = useState<Spot[]>([]);
+  const initialize = () => {
+    setSelectedPeriod(null);
+    setSelectedThemes([]);
+    setSelectedSpots([]);
+  };
+
+  useEffect(() => {
+    initialize();
+  }, [toInitializeTrigger]);
 
   useEffect(() => {
     onSelect({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Head from 'next/head';
-import React, { ReactElement, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import React, { FormEvent, ReactElement, useEffect, useRef, useState } from 'react';
 import { Button, Link, PageContainer, Image } from '~/components/atom';
 import { CourseList, PlaceList } from '~/components/common';
 import Layout from '~/components/common/Layout';
@@ -9,6 +10,8 @@ import { CourseApi } from '~/service';
 import theme from '~/styles/theme';
 
 const HomePage = () => {
+  const router = useRouter();
+  const mainSearchInputRef = useRef<HTMLInputElement>(null);
   // TODO :
   /*
     1. 메인페이지 기능 구현
@@ -22,6 +25,16 @@ const HomePage = () => {
     const result = await CourseApi.getCourses(filter);
     console.log('[Courses] :', result.content);
     setCourseList(result.content);
+  };
+
+  const handleSearch = (e: FormEvent) => {
+    e.preventDefault();
+    if (mainSearchInputRef.current) {
+      const keyword = mainSearchInputRef.current.value;
+      if (keyword) {
+        router.push(`/search/${keyword}`);
+      }
+    }
   };
 
   useEffect(() => {
@@ -40,7 +53,13 @@ const HomePage = () => {
         <PageContainer>
           <SearchArea>
             <Image width={550} src="/assets/search-img.png" alt="여행할 땐 이곳저곳" />
-            <MainSearchInput type="text" placeholder="지역, 장소를 검색해보세요." />
+            <form onSubmit={handleSearch}>
+              <MainSearchInput
+                type="text"
+                placeholder="지역, 장소를 검색해보세요."
+                ref={mainSearchInputRef}
+              />
+            </form>
             <Tags>
               <Button buttonType="tag">#힐링</Button>
               <Button buttonType="tag">#이쁜카페</Button>


### PR DESCRIPTION
# ✅ 이슈번호
closes #96
closes #25 

# 📌 구현 내역
## 설명

1. 검색 api 호출은 search 페이지의 url을 통해 일어납니다.
2. 헤더의 검색바를 통해 검색하는 기능을 구현했습니다. `keyword`를 통해 search 페이지로 이동됩니다.
3. 메인페이지의 검색바도 `keyword`를 통해 search 페이지로 이동시킵니다.
4. 아직 셀렉트 기능은 구현하지 않았는데 셀렉트 컴포넌트 자체에서 state를 가지고 있어 페이지 이동이 일어나는 상황이 아니면 선택된 태그가 변하지 않았습니다. 따라서 태그를 초기화 시키는 어떤 상태(trigger)를 `toInitializeTrigger` 속성에 집어넣어서 그 상태가 변할 때 초기화 되도록 했습니다.

## 이미지

![search](https://user-images.githubusercontent.com/64957267/183258494-3cb0d914-48b1-46ea-9c1d-3bf2db4089d3.gif)



