### PR TITLE
feat: 코스 상세페이지 API 연결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     BASE_URL: process.env.BASE_URL
   },
   images: {
-    domains: ['devcourse-f-s3-storage.s3.ap-northeast-2.amazonaws.com']
+    domains: [process.env.NEXT_PUBLIC_IMAGE_URL]
   }
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ const nextConfig = {
   swcMinify: true,
   env: {
     BASE_URL: process.env.BASE_URL
+  },
+  images: {
+    domains: ['devcourse-f-s3-storage.s3.ap-northeast-2.amazonaws.com']
   }
 };
 

--- a/src/components/common/DetailSidebar/index.tsx
+++ b/src/components/common/DetailSidebar/index.tsx
@@ -3,9 +3,9 @@ import { Icon, Text } from '~/components/atom';
 import theme from '~/styles/theme';
 
 interface DetailSidebarProps {
-  likes: number;
-  isLiked: boolean;
-  isBookmarked: boolean;
+  likes?: number;
+  isLiked?: boolean;
+  isBookmarked?: boolean;
 }
 
 const DetailSidebar = ({ likes = 0, isLiked, isBookmarked }: DetailSidebarProps) => {

--- a/src/components/common/DetailSidebar/index.tsx
+++ b/src/components/common/DetailSidebar/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { Icon, Text } from '~/components/atom';
 import { CourseApi, LikesApi } from '~/service';
@@ -8,20 +9,41 @@ interface DetailSidebarProps {
   likes?: number;
   defaultLiked?: boolean;
   defaultBookmarked?: boolean;
+  isLoggedIn?: boolean;
 }
+/*
+  TODO: 
+  1. 코스와 장소페이지의 처리가 다르게 되도록 구현
+  2. API 완성될 경우 실제 요청 보내도록 처리
 
-const DetailSidebar = ({ likes = 0, defaultLiked, defaultBookmarked }: DetailSidebarProps) => {
+*/
+
+const DetailSidebar = ({
+  likes = 0,
+  defaultLiked,
+  defaultBookmarked,
+  isLoggedIn
+}: DetailSidebarProps) => {
   const [isLiked, setIsLiked] = useState(defaultLiked);
   const [isBookmarked, setIsBookmarked] = useState(defaultBookmarked);
   const [totalLikes, setTotalLikes] = useState(likes);
+  const router = useRouter();
 
   const handleClickLike = async () => {
+    if (!isLoggedIn) {
+      router.push('/login');
+      return;
+    }
     // const result = await LikesApi.likeCourse(id);
     setIsLiked(!isLiked);
     setTotalLikes(isLiked ? totalLikes - 1 : totalLikes + 1);
   };
 
   const handleClickBookmark = async () => {
+    if (!isLoggedIn) {
+      router.push('/login');
+      return;
+    }
     // const result = await LikesApi.likeCourse(id);
     setIsBookmarked(!isBookmarked);
   };

--- a/src/components/common/DetailSidebar/index.tsx
+++ b/src/components/common/DetailSidebar/index.tsx
@@ -1,18 +1,35 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 import { Icon, Text } from '~/components/atom';
+import { CourseApi, LikesApi } from '~/service';
 import theme from '~/styles/theme';
 
 interface DetailSidebarProps {
   likes?: number;
-  isLiked?: boolean;
-  isBookmarked?: boolean;
+  defaultLiked?: boolean;
+  defaultBookmarked?: boolean;
 }
 
-const DetailSidebar = ({ likes = 0, isLiked, isBookmarked }: DetailSidebarProps) => {
+const DetailSidebar = ({ likes = 0, defaultLiked, defaultBookmarked }: DetailSidebarProps) => {
+  const [isLiked, setIsLiked] = useState(defaultLiked);
+  const [isBookmarked, setIsBookmarked] = useState(defaultBookmarked);
+  const [totalLikes, setTotalLikes] = useState(likes);
+
+  const handleClickLike = async () => {
+    // const result = await LikesApi.likeCourse(id);
+    setIsLiked(!isLiked);
+    setTotalLikes(isLiked ? totalLikes - 1 : totalLikes + 1);
+  };
+
+  const handleClickBookmark = async () => {
+    // const result = await LikesApi.likeCourse(id);
+    setIsBookmarked(!isBookmarked);
+  };
+
   return (
     <Container>
       <Sticky>
-        <IconButton>
+        <IconButton onClick={handleClickLike}>
           {isLiked ? (
             <Icon name="heartActive" size={32} />
           ) : (
@@ -20,10 +37,10 @@ const DetailSidebar = ({ likes = 0, isLiked, isBookmarked }: DetailSidebarProps)
           )}
         </IconButton>
         <Text color="darkGray" style={{ marginTop: 8 }}>
-          {likes}
+          {totalLikes}
         </Text>
 
-        <IconButton>
+        <IconButton onClick={handleClickBookmark}>
           {isBookmarked ? (
             <Icon name="bookmarkActive" size={28} />
           ) : (

--- a/src/components/domain/CourseDetail/CourseDetailList/index.tsx
+++ b/src/components/domain/CourseDetail/CourseDetailList/index.tsx
@@ -3,27 +3,28 @@ import { Image, Text, Title } from '~/components/atom';
 import { IPlace } from '~/pages/course/[id]';
 
 interface CourseDetailList {
-  places: IPlace[];
+  places?: IPlace[];
 }
 
 const CourseDetailList = ({ places }: CourseDetailList) => {
   /* TODO:
     1. 추천아이콘 변경하기
   */
+
   return (
     <Container>
-      {places.map((place, index) => (
+      {places?.map((place, index) => (
         <CourseDetailItem key={place.id}>
           <CourseDetailTitle>
             <Title size="md" fontWeight={700}>
               {index + 1}. {place.name}
             </Title>
-            {place.recommended && <button>추천 아이콘</button>}
+            {place.isRecommended && <button>추천 아이콘</button>}
           </CourseDetailTitle>
           <Address size="md" color="gray">
             {place.address}
           </Address>
-          <Image src="/assets/location/jeju.jpg" alt={place.name} style={{ borderRadius: 8 }} />
+          <Image src={place.imageUrl} alt={place.name} style={{ borderRadius: 8 }} />
           <CourseDescription>
             <Text size="lg" color="dark" paragraph>
               {place.description}

--- a/src/components/domain/CourseDetail/CourseDetailList/index.tsx
+++ b/src/components/domain/CourseDetail/CourseDetailList/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Image, Text, Title } from '~/components/atom';
-import { IPlace } from '~/pages/course/[id]';
+import { IPlace } from '~/types/place';
 
 interface CourseDetailList {
   places?: IPlace[];

--- a/src/components/domain/CourseDetail/CourseDetailList/index.tsx
+++ b/src/components/domain/CourseDetail/CourseDetailList/index.tsx
@@ -54,6 +54,7 @@ const CourseDetailTitle = styled.div`
 `;
 const CourseDescription = styled.div`
   margin-top: 37px;
+  line-height: 1.7;
 `;
 
 const Address = styled(Text)`

--- a/src/components/domain/CourseDetail/CourseOverview/OverviewDetailItem.tsx
+++ b/src/components/domain/CourseDetail/CourseOverview/OverviewDetailItem.tsx
@@ -2,20 +2,25 @@ import styled from '@emotion/styled';
 import { Text } from '~/components/atom';
 
 interface OverviewDetailItemProps {
-  title: string;
-  list: string[];
+  title?: string;
+  list?: string[];
+  theme?: boolean;
 }
 
-const OverviewDetailItem = ({ title, list }: OverviewDetailItemProps) => {
+const OverviewDetailItem = ({ title, list, theme }: OverviewDetailItemProps) => {
+  const LAST_INDEX = list !== undefined && list.length - 1;
+
   return (
     <Container>
       <Text size="sm" color="blueGray">
         {title}
       </Text>
 
-      {list.map((item) => (
+      {list?.map((item, index) => (
         <Text key={item} fontWeight={500}>
+          {theme && '#'}
           {item}
+          {!theme && index !== LAST_INDEX && ','}
         </Text>
       ))}
     </Container>

--- a/src/components/domain/CourseDetail/CourseOverview/OverviewItem.tsx
+++ b/src/components/domain/CourseDetail/CourseOverview/OverviewItem.tsx
@@ -3,8 +3,8 @@ import { Icon, Text } from '~/components/atom';
 import { IconName } from '~/components/atom/Icon/types';
 
 interface OverViewItemProps {
-  title: string;
-  content: string;
+  title?: string;
+  content?: string;
   iconName: IconName;
 }
 

--- a/src/components/domain/CourseDetail/CourseOverview/index.tsx
+++ b/src/components/domain/CourseDetail/CourseOverview/index.tsx
@@ -4,11 +4,11 @@ import OverviewDetailItem from './OverviewDetailItem';
 import OverviewItem from './OverviewItem';
 
 interface CourseOverviewProps {
-  region: string;
-  period: string;
-  courseCount: number;
-  themes: string[];
-  spots: string[];
+  region?: string;
+  period?: string;
+  courseCount?: number;
+  themes?: string[];
+  spots?: string[];
 }
 
 const CourseOverview = ({ region, period, courseCount, themes, spots }: CourseOverviewProps) => {
@@ -20,7 +20,7 @@ const CourseOverview = ({ region, period, courseCount, themes, spots }: CourseOv
         <OverviewItem title="총 코스" content={courseCount + '코스'} iconName="route" />
       </OverviewList>
       <OverviewDetailList>
-        <OverviewDetailItem title="여행테마" list={themes} />
+        <OverviewDetailItem title="여행테마" list={themes} theme />
         <OverviewDetailItem title="포함장소" list={spots} />
       </OverviewDetailList>
     </Container>

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -7,7 +7,7 @@ import CourseSliderItem from './CourseSliderItem';
 import { IPlace } from '~/pages/course/[id]';
 
 interface CourseSliderProps {
-  places: IPlace[];
+  places?: IPlace[];
 }
 
 const CourseSlider = ({ places }: CourseSliderProps) => {

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -4,10 +4,10 @@ import 'slick-carousel/slick/slick-theme.css';
 import styled from '@emotion/styled';
 import theme from '~/styles/theme';
 import CourseSliderItem from './CourseSliderItem';
-import { IPlace } from '~/pages/course/[id]';
+import { PlaceData } from '~/types/place';
 
 interface CourseSliderProps {
-  places?: IPlace[];
+  places?: PlaceData[];
 }
 
 const CourseSlider = ({ places }: CourseSliderProps) => {

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -4,10 +4,10 @@ import 'slick-carousel/slick/slick-theme.css';
 import styled from '@emotion/styled';
 import theme from '~/styles/theme';
 import CourseSliderItem from './CourseSliderItem';
-import { PlaceData } from '~/types/place';
+import { IPlace } from '~/types/place';
 
 interface CourseSliderProps {
-  places?: PlaceData[];
+  places?: IPlace[];
 }
 
 const CourseSlider = ({ places }: CourseSliderProps) => {

--- a/src/components/domain/Map/CourseMap/index.tsx
+++ b/src/components/domain/Map/CourseMap/index.tsx
@@ -3,19 +3,8 @@ import { Map, MapMarker, CustomOverlayMap, Polyline } from 'react-kakao-maps-sdk
 import markerIcon from 'public/assets/place/course.png';
 import Script from 'next/script';
 import styled from '@emotion/styled';
+import { IPlace } from '~/types/place';
 
-export interface IPlace {
-  id: number;
-  name: string;
-  description: string;
-  address: string;
-  latitude: string;
-  longitude: string;
-  phoneNumber: string;
-  imageUrl: string;
-  isRecommended: boolean;
-  isThumbnail: boolean;
-}
 interface CourseType {
   id: number;
   latitude: string;

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -14,38 +14,7 @@ import CourseMap from '~/components/domain/Map/CourseMap';
 import { useUser } from '~/hooks/useUser';
 import { CourseApi } from '~/service';
 import theme from '~/styles/theme';
-
-interface ICourseData {
-  id: number;
-  title: string;
-  thumbnail: string;
-  region: string;
-  period: string;
-  themes: string[];
-  spots: string[];
-  places: IPlace[];
-  likes: number;
-  isLiked: boolean;
-  isBookmarked: boolean;
-  nickname: string;
-  userId: number;
-  profileImage: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface IPlace {
-  id: number;
-  name: string;
-  description: string;
-  address: string;
-  latitude: string;
-  longitude: string;
-  phoneNumber: string;
-  imageUrl: string;
-  isRecommended: boolean;
-  isThumbnail: boolean;
-}
+import { ICourseDetail } from '~/types/course';
 
 const CourseDetail: NextPage = () => {
   /* TODO
@@ -54,7 +23,7 @@ const CourseDetail: NextPage = () => {
     3. 수정/삭제 버튼 구현
   */
   const { currentUser, isLoggedIn } = useUser();
-  const [detailData, setDetailData] = useState<ICourseData | null>(null);
+  const [detailData, setDetailData] = useState<ICourseDetail | null>(null);
   const [like, setLike] = useState<number>(0);
   const router = useRouter();
   const courseId = router.query.id;

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -53,15 +53,20 @@ const CourseDetail: NextPage = () => {
     2. 업로드, 수정 날짜 가공하여 적용
     3. 수정/삭제 버튼 구현
   */
-
+  const { currentUser, isLoggedIn } = useUser();
   const [detailData, setDetailData] = useState<ICourseData | null>(null);
+
   const router = useRouter();
   const courseId = router.query.id;
-  const { currentUser } = useUser();
 
   const getDetailInfo = async (courseId: string) => {
-    const result = await CourseApi.read(courseId);
-    setDetailData(result);
+    if (isLoggedIn) {
+      const result = await CourseApi.authRead(courseId);
+      setDetailData(result);
+    } else {
+      const result = await CourseApi.read(courseId);
+      setDetailData(result);
+    }
   };
 
   useEffect(() => {

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
 import { Link, PageContainer, Text, Title } from '~/components/atom';
 import Avatar from '~/components/atom/Avatar';
 import Comment from '~/components/common/Comment';
@@ -10,6 +11,8 @@ import CourseDetailList from '~/components/domain/CourseDetail/CourseDetailList'
 import CourseOverview from '~/components/domain/CourseDetail/CourseOverview';
 import CourseSlider from '~/components/domain/CourseSlider';
 import CourseMap from '~/components/domain/Map/CourseMap';
+import { useUser } from '~/hooks/useUser';
+import { CourseApi } from '~/service';
 import theme from '~/styles/theme';
 
 interface ICourseData {
@@ -38,89 +41,37 @@ export interface IPlace {
   address: string;
   latitude: string;
   longitude: string;
-  category: string;
-  phone: string;
-  recommended: boolean;
+  phoneNumber: string;
+  imageUrl: string;
+  isRecommended: boolean;
+  isThumbnail: boolean;
 }
-
-const courseData: ICourseData = {
-  id: 12,
-  title: '[1박 2일] 제주도 여행 추천!!!',
-  thumbnail: '',
-  region: '제주',
-  period: '당일',
-  themes: ['혼자여행', '데이트코스'],
-  spots: ['카페', '음식점'],
-  places: [
-    {
-      id: 1,
-      name: '인천공항',
-      description: '인천공항에 다녀왔어요',
-      address: '인천 중구 공항로 207 인천국제공항역',
-      latitude: '35.0768018',
-      longitude: '129.023402',
-      category: '',
-      phone: '',
-      recommended: false
-    },
-    {
-      id: 2,
-      name: '인천공항',
-      description: '인천공항에 다녀왔어요',
-      address: '인천 중구 공항로 207 인천국제공항역',
-      latitude: '35.1538826',
-      longitude: '129.118628',
-      category: '',
-      phone: '',
-      recommended: false
-    },
-    {
-      id: 3,
-      name: '인천공항',
-      description: '인천공항에 다녀왔어요',
-      address: '인천 중구 공항로 207 인천국제공항역',
-      latitude: '35.0554585',
-      longitude: '129.087973',
-      category: '',
-      phone: '',
-      recommended: true
-    }
-    // {
-    //   id: 4,
-    //   name: '인천공항',
-    //   description: '인천공항에 다녀왔어요',
-    //   address: '인천 중구 공항로 207 인천국제공항역',
-    //   latitude: '35.0553585',
-    //   longitude: '129.087783',
-    //   category: '',
-    //   phone: '',
-    //   recommended: false
-    // }
-  ],
-  likes: 12,
-  isLiked: false,
-  isBookmarked: false,
-  nickname: 'Jinist',
-  userId: 1,
-  profileImage: '',
-  createdAt: '',
-  updatedAt: ''
-};
-
-const courseMapData = courseData.places.map((place) => {
-  return {
-    placeId: place.id,
-    lat: Number(place.latitude),
-    lng: Number(place.longitude),
-    placeName: place.name
-  };
-});
 
 const CourseDetail: NextPage = () => {
   /* TODO
     1. 추천 아이콘 작업
     2. 업로드, 수정 날짜 가공하여 적용
+    3. 수정/삭제 버튼 구현
   */
+
+  const [detailData, setDetailData] = useState<ICourseData | null>(null);
+  const router = useRouter();
+  const courseId = router.query.id;
+  const { currentUser } = useUser();
+
+  const getDetailInfo = async (courseId: string) => {
+    const result = await CourseApi.read(courseId);
+    setDetailData(result);
+  };
+
+  useEffect(() => {
+    if (typeof courseId === 'string') {
+      getDetailInfo(courseId);
+      return;
+    }
+    router.push('/');
+  }, [courseId, router]);
+
   return (
     <React.Fragment>
       <Head>
@@ -134,54 +85,56 @@ const CourseDetail: NextPage = () => {
           <CourseDetailHeader>
             <CourseTitle>
               <Title level={2} size="lg" fontWeight={700} block>
-                {courseData.title}
+                {detailData?.title}
               </Title>
-              <HeaderButtons>
-                <button>수정</button>
-                <button>삭제</button>
-              </HeaderButtons>
+              {currentUser.user.id === detailData?.userId && (
+                <HeaderButtons>
+                  <button>수정</button>
+                  <button>삭제</button>
+                </HeaderButtons>
+              )}
             </CourseTitle>
             <Text color="gray">
-              업로드 날짜: {courseData.createdAt} 수정된 날짜: {courseData.updatedAt}
+              업로드 날짜: {detailData?.createdAt} 수정된 날짜: {detailData?.updatedAt}
             </Text>
             <Profile>
-              <Link href={`/userinfo/${courseData.userId}`}>
+              <Link href={`/userinfo/${detailData?.userId}`}>
                 <Avatar size={66} />
               </Link>
               <Text color="dark" fontWeight={500}>
-                {courseData.nickname}
+                {detailData?.nickname}
               </Text>
             </Profile>
           </CourseDetailHeader>
 
           <CourseDetails>
             <CourseOverview
-              themes={courseData.themes}
-              period={courseData.period}
-              region={courseData.region}
-              courseCount={courseData.places.length}
-              spots={courseData.spots}
+              themes={detailData?.themes}
+              period={detailData?.period}
+              region={detailData?.region}
+              courseCount={detailData?.places.length}
+              spots={detailData?.spots}
             />
 
             <TravelRoute>
               <DetailTitle size="md" fontWeight={700}>
                 여행경로
               </DetailTitle>
-              <CourseMap course={courseMapData} />
+              {/* <CourseMap course={courseMapData} /> */}
             </TravelRoute>
             <TravelCourse>
               <DetailTitle size="md" fontWeight={700}>
                 다녀온 코스
               </DetailTitle>
-              <CourseSlider places={courseData.places} />
+              <CourseSlider places={detailData?.places} />
             </TravelCourse>
-            <CourseDetailList places={courseData.places} />
+            <CourseDetailList places={detailData?.places} />
           </CourseDetails>
           <Comment />
           <DetailSidebar
-            likes={courseData.likes}
-            isLiked={courseData.isLiked}
-            isBookmarked={courseData.isBookmarked}
+            likes={detailData?.likes}
+            isLiked={detailData?.isLiked}
+            isBookmarked={detailData?.isBookmarked}
           />
         </PageContainer>
       </main>

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -55,7 +55,7 @@ const CourseDetail: NextPage = () => {
   */
   const { currentUser, isLoggedIn } = useUser();
   const [detailData, setDetailData] = useState<ICourseData | null>(null);
-
+  const [like, setLike] = useState<number>(0);
   const router = useRouter();
   const courseId = router.query.id;
 
@@ -63,9 +63,11 @@ const CourseDetail: NextPage = () => {
     if (isLoggedIn) {
       const result = await CourseApi.authRead(courseId);
       setDetailData(result);
+      setLike(result.likes);
     } else {
       const result = await CourseApi.read(courseId);
       setDetailData(result);
+      setLike(result.likes);
     }
   };
 
@@ -74,7 +76,7 @@ const CourseDetail: NextPage = () => {
       getDetailInfo(courseId);
       return;
     }
-    router.push('/');
+    // router.push('/');
   }, [courseId, router]);
 
   return (
@@ -137,9 +139,9 @@ const CourseDetail: NextPage = () => {
           </CourseDetails>
           <Comment />
           <DetailSidebar
-            likes={detailData?.likes}
-            isLiked={detailData?.isLiked}
-            isBookmarked={detailData?.isBookmarked}
+            likes={like}
+            defaultLiked={detailData?.isLiked}
+            defaultBookmarked={detailData?.isBookmarked}
           />
         </PageContainer>
       </main>

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -28,7 +28,7 @@ const CourseDetail: NextPage = () => {
   const router = useRouter();
   const courseId = router.query.id;
 
-  const getDetailInfo = async (courseId: string) => {
+  const getDetailInfo = async (courseId: number) => {
     if (isLoggedIn) {
       const result = await CourseApi.authRead(courseId);
       if (!result) {
@@ -51,7 +51,12 @@ const CourseDetail: NextPage = () => {
 
   useEffect(() => {
     if (typeof courseId === 'string') {
-      getDetailInfo(courseId);
+      if (!Number.isNaN(Number(courseId))) {
+        getDetailInfo(Number(courseId));
+        return;
+      }
+
+      router.push('/');
       return;
     }
     // 의존성 추가 시 네트워크 요청 2번 함

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -31,11 +31,19 @@ const CourseDetail: NextPage = () => {
   const getDetailInfo = async (courseId: string) => {
     if (isLoggedIn) {
       const result = await CourseApi.authRead(courseId);
+      if (!result) {
+        // 임시로 값 없을 경우 처리
+        router.push('/');
+        return;
+      }
       setDetailData(result);
       setLike(result.likes);
-      console.log(result.places[0].latitude, result.places[0].longitude);
     } else {
       const result = await CourseApi.read(courseId);
+      if (!result) {
+        router.push('/');
+        return;
+      }
       setDetailData(result);
       setLike(result.likes);
     }
@@ -46,7 +54,7 @@ const CourseDetail: NextPage = () => {
       getDetailInfo(courseId);
       return;
     }
-    // router.push('/');
+    // 의존성 추가 시 네트워크 요청 2번 함
   }, [courseId, router]);
 
   if (!detailData) {
@@ -101,7 +109,7 @@ const CourseDetail: NextPage = () => {
               <DetailTitle size="md" fontWeight={700}>
                 여행경로
               </DetailTitle>
-              <CourseMap course={detailData?.places} />
+              <CourseMap course={detailData.places} />
             </TravelRoute>
             <TravelCourse>
               <DetailTitle size="md" fontWeight={700}>

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -124,6 +124,7 @@ const CourseDetail: NextPage = () => {
             likes={like}
             defaultLiked={detailData?.isLiked}
             defaultBookmarked={detailData?.isBookmarked}
+            isLoggedIn={isLoggedIn}
           />
         </PageContainer>
       </main>

--- a/src/pages/place/[postId].tsx
+++ b/src/pages/place/[postId].tsx
@@ -89,8 +89,8 @@ const PlaceDetailByPostId = ({ post }: Props) => {
         <Container type="detail" style={{ position: 'relative' }}>
           <DetailSidebar
             likes={post.likeCount}
-            isLiked={post.liked}
-            isBookmarked={post.bookmarked}
+            defaultLiked={post.liked}
+            defaultBookmarked={post.bookmarked}
           />
           <PostHeader>
             <Title level={1} size="lg" fontWeight={700} block>

--- a/src/service/domains/course.ts
+++ b/src/service/domains/course.ts
@@ -44,13 +44,12 @@ class CourseApi extends Api {
   };
 
   read = async (courseId: string) => {
-    /* try {
+    try {
       const response = await this.baseInstance.get(`${this.path}/${courseId}`);
-      console.log(response);
       return response.data;
     } catch (e) {
       console.error(`코스 상세 조회 오류: ${e}`);
-    } */
+    }
   };
 
   update = async (formData: FormData) => {

--- a/src/service/domains/course.ts
+++ b/src/service/domains/course.ts
@@ -52,6 +52,15 @@ class CourseApi extends Api {
     }
   };
 
+  authRead = async (courseId: string) => {
+    try {
+      const response = await this.authInstance.get(`${this.path}/${courseId}`);
+      return response.data;
+    } catch (e) {
+      console.error(`코스 상세 조회 오류: ${e}`);
+    }
+  };
+
   update = async (formData: FormData) => {
     /* try {
       const response = await this.authInstance.put(this.path, formData);

--- a/src/service/domains/course.ts
+++ b/src/service/domains/course.ts
@@ -43,7 +43,7 @@ class CourseApi extends Api {
     }
   };
 
-  read = async (courseId: string) => {
+  read = async (courseId: number) => {
     try {
       const response = await this.baseInstance.get(`${this.path}/${courseId}`);
       return response.data;
@@ -52,7 +52,7 @@ class CourseApi extends Api {
     }
   };
 
-  authRead = async (courseId: string) => {
+  authRead = async (courseId: number) => {
     try {
       const response = await this.authInstance.get(`${this.path}/${courseId}`);
       return response.data;

--- a/src/service/domains/likes.ts
+++ b/src/service/domains/likes.ts
@@ -5,12 +5,12 @@ class LikesApi extends Api {
 
   likeCourse = async (courseId: number) => {
     const response = await this.authInstance.get(`${this.path}/courses/${courseId}`);
-    return response;
+    return response.data;
   };
 
   likePlace = async (placeId: number) => {
     const response = await this.authInstance.get(`${this.path}/places/${placeId}`);
-    return response;
+    return response.data;
   };
 }
 

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,3 +1,5 @@
+import { IPlace } from './place';
+
 export interface ICourseItem {
   id: number;
   title: string;
@@ -10,6 +12,25 @@ export interface ICourseItem {
   isBookmarked: boolean;
   nickname: string;
   profileUrl: string;
+}
+
+export interface ICourseDetail {
+  id: number;
+  title: string;
+  thumbnail: string;
+  region: string;
+  period: string;
+  themes: string[];
+  spots: string[];
+  places: IPlace[];
+  likes: number;
+  isLiked: boolean;
+  isBookmarked: boolean;
+  nickname: string;
+  userId: number;
+  profileImage: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface CourseFilter {

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -7,3 +7,16 @@ export interface IPlaceItem {
   thumbnail: string;
   bookmarked: boolean;
 }
+
+export interface IPlace {
+  id: number;
+  name: string;
+  description: string;
+  address: string;
+  latitude: string;
+  longitude: string;
+  phoneNumber: string;
+  imageUrl: string;
+  isRecommended: boolean;
+  isThumbnail: boolean;
+}


### PR DESCRIPTION
# ✅ 이슈번호
closes #97 

# 📌 구현 내역
## 코스 상세페이지 API 연결
- 코스 상세페이지 API 연결하였습니다.
- 존재하지 않는 코스 페이지 접근 시 (api로 받는 값이 없을 경우) 메인 페이지로 이동됩니다.

## DetailSidebar
- 로그인하지 않은 상태에서 좋아요/북마크 버튼 클릭 시 login페이지로 이동됩니다.
- 
- 좋아요/북마크 클릭 시 버튼색상 변경, count 변경이 되지만
API는 수정이 필요하여 백엔드에 요청한 상태이기 때문에 연결은 추후 구현할 예정입니다.
-> 추후 구현하면서 장소 상세에서도 사용할 수 있게 변경 처리할 예정입니다
![sidebar](https://user-images.githubusercontent.com/81489300/183263678-926d77eb-ff33-452a-8fc9-c3cf7e184a37.gif)

## type 분리
- types/course , types/place 경로에  type추가해두었습니다.
- data의 interface의 경우 앞에 I를 붙여서 중복되지않게 맞추는게 좋을 것 같습니다.
![image](https://user-images.githubusercontent.com/81489300/183263791-e4912c53-66a7-4b5f-8c90-8181c2b07e2d.png)
