### PR TITLE
feat: 코스 상세페이지 말줄임 처리 및 날짜 데이터 변경

### DIFF
--- a/src/components/atom/Image/index.tsx
+++ b/src/components/atom/Image/index.tsx
@@ -1,24 +1,29 @@
 import styled from '@emotion/styled';
 import NextImage, { ImageProps as NextImageProps } from 'next/image';
+import { useState } from 'react';
 
-interface ImageProps extends NextImageProps {
+interface ImageProps {
   width?: number | string;
+  height?: number | string;
+  cover?: boolean;
 }
 
-const Image = ({ width = '100%', ...props }: ImageProps) => {
+const Image = ({ width = '100%', height, cover, ...props }: ImageProps & NextImageProps) => {
   return (
-    <ImageWrapper width={width}>
-      <NextImage layout="fill" objectFit="contain" {...props} />
+    <ImageWrapper width={width} height={height}>
+      <NextImage layout="fill" objectFit={cover ? 'cover' : 'contain'} {...props} />
     </ImageWrapper>
   );
 };
 
 export default Image;
 
-const ImageWrapper = styled.div<Pick<ImageProps, 'width'>>`
+const ImageWrapper = styled.div<ImageProps>`
   width: ${({ width }) => (typeof width === 'number' ? width + 'px' : width)};
+  height: ${({ height }) => (typeof height === 'number' ? height + 'px' : height)};
   & > span {
     position: unset !important;
+    height: ${({ height }) => (typeof height === 'number' ? height + 'px' : height)} !important;
     & img {
       position: relative !important;
       height: auto !important;

--- a/src/components/atom/Text/index.tsx
+++ b/src/components/atom/Text/index.tsx
@@ -15,8 +15,6 @@ export interface TextProps {
   style?: CSSProperties;
 }
 
-let tag: 'span' | 'p' = 'span';
-
 const Text = ({
   children,
   size = 'sm',
@@ -25,44 +23,25 @@ const Text = ({
   ellipsis,
   paragraph,
   fontWeight,
+  style,
   ...props
 }: TextProps) => {
-  tag = paragraph ? 'p' : 'span';
+  const Tag = paragraph ? 'p' : 'span';
+
+  const fontStyle = {
+    fontSize: size && (typeof size === 'number' ? size + 'px' : FONT_SIZES[size] + 'px'),
+    color: color && (FONT_COLORS[color] || color),
+    fontWeight: fontWeight && fontWeight,
+    display: block ? 'block' : 'inline-block'
+  };
 
   return (
-    <StyledText
-      size={size}
-      color={color}
-      ellipsis={ellipsis}
-      fontWeight={fontWeight}
-      block={block}
-      {...props}
-    >
+    <Tag className={ellipsis ? 'ellipsis' : ''} style={{ ...fontStyle, ...style }} {...props}>
       {children}
-    </StyledText>
+    </Tag>
   );
 };
 
 Text.Button = TextButton;
 
 export default Text;
-
-const StyledText = styled[tag]<Omit<TextProps, 'children'>>`
-  font-size: ${({ size }) =>
-    size && (typeof size === 'number' ? size + 'px' : FONT_SIZES[size] + 'px')};
-
-  color: ${({ color }) => color && (FONT_COLORS[color] || color)};
-
-  display: ${({ block }) => (block ? 'block' : 'inline-block')};
-
-  ${({ ellipsis }) =>
-    ellipsis &&
-    `
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `};
-
-  font-weight: ${({ fontWeight }) => fontWeight && fontWeight};
-`;

--- a/src/components/atom/Title/index.tsx
+++ b/src/components/atom/Title/index.tsx
@@ -63,4 +63,5 @@ const Styled = styled[tag]<Omit<TitleProps, 'children'>>`
     text-overflow: ellipsis;
     white-space: nowrap;
   `}
+  word-break: break-all;
 `;

--- a/src/components/common/CourseList/CourseItem.tsx
+++ b/src/components/common/CourseList/CourseItem.tsx
@@ -34,7 +34,7 @@ const CourseItem = ({ course, grid = 3 }: CourseItemProps) => {
           </ThumbnailInfo>
         </ThumbnailWrapper>
         <CourseInfo className="courseInfo">
-          <Text block ellipsis>
+          <Text size={17} block ellipsis fontWeight={500}>
             {places.map((place, index) => (
               <React.Fragment key={place}>
                 {place}
@@ -42,7 +42,7 @@ const CourseItem = ({ course, grid = 3 }: CourseItemProps) => {
               </React.Fragment>
             ))}
           </Text>
-          <Text block style={{ marginTop: 4 }}>
+          <Text block style={{ marginTop: 4 }} ellipsis>
             {themes.map((item) => (
               <React.Fragment key={item}>#{item} </React.Fragment>
             ))}

--- a/src/components/domain/CourseDetail/CourseDetailList/index.tsx
+++ b/src/components/domain/CourseDetail/CourseDetailList/index.tsx
@@ -24,7 +24,9 @@ const CourseDetailList = ({ places }: CourseDetailList) => {
           <Address size="md" color="gray">
             {place.address}
           </Address>
-          <Image src={place.imageUrl} alt={place.name} style={{ borderRadius: 8 }} />
+          <ImageViewer>
+            {place.imageUrl && <Image src={place.imageUrl} alt={place.name} height="100%" cover />}
+          </ImageViewer>
           <CourseDescription>
             <ContentText size="lg" color="dark" paragraph>
               {place.description}
@@ -63,4 +65,12 @@ const Address = styled(Text)`
 
 const ContentText = styled(Text)`
   white-space: pre;
+`;
+
+const ImageViewer = styled.div`
+  height: 500px;
+  background-color: #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
 `;

--- a/src/components/domain/CourseDetail/CourseDetailList/index.tsx
+++ b/src/components/domain/CourseDetail/CourseDetailList/index.tsx
@@ -26,9 +26,9 @@ const CourseDetailList = ({ places }: CourseDetailList) => {
           </Address>
           <Image src={place.imageUrl} alt={place.name} style={{ borderRadius: 8 }} />
           <CourseDescription>
-            <Text size="lg" color="dark" paragraph>
+            <ContentText size="lg" color="dark" paragraph>
               {place.description}
-            </Text>
+            </ContentText>
           </CourseDescription>
         </CourseDetailItem>
       ))}
@@ -59,4 +59,8 @@ const CourseDescription = styled.div`
 
 const Address = styled(Text)`
   margin-bottom: 37px;
+`;
+
+const ContentText = styled(Text)`
+  white-space: pre;
 `;

--- a/src/components/domain/CourseDetail/CourseOverview/OverviewDetailItem.tsx
+++ b/src/components/domain/CourseDetail/CourseOverview/OverviewDetailItem.tsx
@@ -12,17 +12,20 @@ const OverviewDetailItem = ({ title, list, theme }: OverviewDetailItemProps) => 
 
   return (
     <Container>
-      <Text size="sm" color="blueGray">
-        {title}
-      </Text>
-
-      {list?.map((item, index) => (
-        <Text key={item} fontWeight={500}>
-          {theme && '#'}
-          {item}
-          {!theme && index !== LAST_INDEX && ','}
+      <Wrapper>
+        <Text size="sm" color="blueGray">
+          {title}
         </Text>
-      ))}
+      </Wrapper>
+      <Wrapper>
+        {list?.map((item, index) => (
+          <Text key={item} fontWeight={500}>
+            {theme && '#'}
+            {item}
+            {!theme && index !== LAST_INDEX && ','}
+          </Text>
+        ))}
+      </Wrapper>
     </Container>
   );
 };
@@ -31,7 +34,13 @@ export default OverviewDetailItem;
 
 const Container = styled.li`
   margin-right: 30px;
+  max-width: 50%;
+  line-height: 1.5;
+  display: flex;
   span {
     margin-left: 8px;
+    white-space: nowrap;
   }
 `;
+
+const Wrapper = styled.div``;

--- a/src/components/domain/CourseSlider/CourseSliderItem.tsx
+++ b/src/components/domain/CourseSlider/CourseSliderItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Button, Image, Link, Title } from '~/components/atom';
+import { Button, Link, Title } from '~/components/atom';
 import theme from '~/styles/theme';
 
 interface CourseSliderItemProps {
@@ -7,14 +7,17 @@ interface CourseSliderItemProps {
   id: number;
   index: number;
   lastCount: number;
+  imageUrl: string;
 }
 
 const DOT_BG = 'url(/assets/dot-gray.png)';
 const LINE_BG = 'url(/assets/line-bluegray.png)';
 
-const CourseSliderItem = ({ name, id, index, lastCount }: CourseSliderItemProps) => {
+const CourseSliderItem = ({ name, id, index, lastCount, imageUrl }: CourseSliderItemProps) => {
   const IS_START = index === 0;
   const IS_END = index === lastCount - 1;
+
+  const IMAGE_URL = imageUrl ? imageUrl : '';
 
   return (
     <div className="card-item">
@@ -30,7 +33,7 @@ const CourseSliderItem = ({ name, id, index, lastCount }: CourseSliderItemProps)
         <Circle>{index + 1}</Circle>
       </CourseLine>
       <CourseCard>
-        <CardImage style={{ backgroundImage: `url(/assets/location/jeju.jpg)` }}></CardImage>
+        <CardImage style={{ backgroundImage: `url(${IMAGE_URL})` }}></CardImage>
         <CardInfo>
           <Title>{name}</Title>
           <Link href={`/place/${id}`}>
@@ -44,7 +47,7 @@ const CourseSliderItem = ({ name, id, index, lastCount }: CourseSliderItemProps)
 
 export default CourseSliderItem;
 
-const { borderGray, mainColor } = theme.color;
+const { borderGray, mainColor, backgroundGray } = theme.color;
 
 const CourseLine = styled.div`
   margin-bottom: 18px;
@@ -89,6 +92,7 @@ const CardImage = styled.div`
   border-radius: 8px 8px 0 0;
   height: 230px;
   background-size: cover;
+  background-color: ${backgroundGray};
 `;
 
 const CardInfo = styled.div`

--- a/src/components/domain/CourseSlider/CourseSliderItem.tsx
+++ b/src/components/domain/CourseSlider/CourseSliderItem.tsx
@@ -35,7 +35,9 @@ const CourseSliderItem = ({ name, id, index, lastCount, imageUrl }: CourseSlider
       <CourseCard>
         <CardImage style={{ backgroundImage: `url(${IMAGE_URL})` }}></CardImage>
         <CardInfo>
-          <Title>{name}</Title>
+          <TitleContainer>
+            <Title ellipsis>{name}</Title>
+          </TitleContainer>
           <Link href={`/place/${id}`}>
             <Button buttonType="borderPrimary">장소정보보기</Button>
           </Link>
@@ -104,4 +106,11 @@ const CardInfo = styled.div`
   border: 1px solid ${borderGray};
   border-top: none;
   border-radius: 0 0 8px 8px;
+  width: 100%;
+  box-sizing: border-box;
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  text-align: center;
 `;

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -28,6 +28,7 @@ const CourseSlider = ({ places }: CourseSliderProps) => {
           id={place.id}
           index={index}
           lastCount={places.length}
+          imageUrl={place.imageUrl}
         />
       ))}
     </StyledSlider>

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -15,6 +15,7 @@ import { useUser } from '~/hooks/useUser';
 import { CourseApi } from '~/service';
 import theme from '~/styles/theme';
 import { ICourseDetail } from '~/types/course';
+import { sliceDate } from '~/utils/converter';
 
 const CourseDetail: NextPage = () => {
   /* TODO
@@ -88,9 +89,11 @@ const CourseDetail: NextPage = () => {
                 </HeaderButtons>
               )}
             </CourseTitle>
-            <Text color="gray">
-              업로드 날짜: {detailData?.createdAt} 수정된 날짜: {detailData?.updatedAt}
-            </Text>
+            <CourseDate>
+              <Text color="gray">업로드한 날: {sliceDate(detailData.createdAt)}</Text>
+              <Text color="gray">마지막 수정한 날: {sliceDate(detailData?.updatedAt)}</Text>
+            </CourseDate>
+
             <Profile>
               <Link href={`/userinfo/${detailData?.userId}`}>
                 <Avatar size={66} />
@@ -149,6 +152,12 @@ const CourseTitle = styled.div`
   display: flex;
   justify-content: space-between;
   margin-bottom: 12px;
+`;
+
+const CourseDate = styled.div`
+  span {
+    margin-right: 14px;
+  }
 `;
 
 const HeaderButtons = styled.div`

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,3 +33,14 @@ body.modal-open {
   width: 100%;
   overflow-y: hidden;
 }
+
+.ellipsis {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+span {
+  line-height: 1.5;
+}

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -4,3 +4,7 @@ export const ObjectToQuery = (obj: any) => {
     .map((e) => e.join('='))
     .join('&')}`;
 };
+
+export const sliceDate = (data: string) => {
+  return data.substring(0, 10);
+};


### PR DESCRIPTION
# ✅ 이슈번호
closes #110 

# 📌 구현 내역

- 코스 상세페이지에 장소 image 연결
- 서버에서 받은 날짜 데이터가 slice되서 노출되도록 변경
![image](https://user-images.githubusercontent.com/81489300/183311177-a46ad4dc-0167-46c5-8475-dac204f96873.png)

- 코스 이미지가 정해진 크기에 맞게 출력되도록 변경.

## 추가 처리

- 코스 상세페이지에서 텍스트가 많아서 글이 줄바꿈되지 않고 텍스트가 초과되는 부분 등
레이아웃 어긋나는부분 수정했습니다.

- Text 컴포넌트가 paragraph설정이 되지 않아 내부 코드를 변경하였습니다.
* 기존과 변경된 점: styled(Text)로 컴포넌트를 만들 경우 Text 컴포넌트의 style이 적용됩니다.
예시)
```javascript
<StyledText color="main></StyledText >


const StyledText = styled(Text)`
  color: red; // 적용 안됨
`
```

- custom image 컴포넌트 height 지정 후 이미지 비율 맞출 수 있도록 height, cover props 추가
 : 컨테이너에 height 적용하고 아래처럼 사용하면 이미지 일그러짐 없이 사용 가능합니다.
![image](https://user-images.githubusercontent.com/81489300/183312031-5df2b1f5-adfd-4a34-ab86-9079f9b84b16.png)

- 기타 css style 적용 했습니다.
