### PR TITLE
feat: 검색페이지 태그 필터링 기능 구현

### DIFF
--- a/src/components/common/SelectTags/index.tsx
+++ b/src/components/common/SelectTags/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import React, { CSSProperties, useEffect, useState } from 'react';
 import theme from '~/styles/theme';
 import { Period, SearchTagsValues, Spot, Theme } from '~/types';
+import { removeList, updateList } from '~/utils/converter';
 import PeriodTags from './PeriodTags';
 import SpotTags from './SpotTags';
 import ThemeTags from './ThemeTags';
@@ -26,36 +27,40 @@ const SelectTags = ({ style, onSelect, toInitializeTrigger }: SelectTagsProps) =
     initialize();
   }, [toInitializeTrigger]);
 
-  useEffect(() => {
-    onSelect({
-      period: selectedPeriod,
-      theme: selectedThemes,
-      spot: selectedSpots
-    });
-  }, [selectedPeriod, selectedThemes, selectedSpots, onSelect]);
-
   const handleSelectPeriod = (period: Period) => {
-    if (selectedPeriod === period) {
-      setSelectedPeriod(() => null);
-    } else {
-      setSelectedPeriod(() => period);
-    }
+    const isSame = selectedPeriod === period;
+
+    onSelect({
+      period: isSame ? null : period,
+      theme: [...selectedThemes],
+      spot: [...selectedSpots]
+    });
+
+    isSame ? setSelectedPeriod(null) : setSelectedPeriod(period);
   };
 
   const handleSelectThemes = (theme: Theme, isSelected: boolean) => {
-    if (!isSelected) {
-      setSelectedThemes((prev) => [...prev, theme]);
-    } else {
-      setSelectedThemes((prev) => prev.filter((prevTheme) => prevTheme !== theme));
-    }
+    onSelect({
+      period: selectedPeriod,
+      theme: isSelected ? removeList(selectedThemes, theme) : updateList(selectedThemes, theme),
+      spot: [...selectedSpots]
+    });
+
+    isSelected
+      ? setSelectedThemes(removeList(selectedThemes, theme))
+      : setSelectedThemes(updateList(selectedThemes, theme));
   };
 
   const handleSelectSpots = (spot: Spot, isSelected: boolean) => {
-    if (!isSelected) {
-      setSelectedSpots((prev) => [...prev, spot]);
-    } else {
-      setSelectedSpots((prev) => prev.filter((prevSpot) => prevSpot !== spot));
-    }
+    onSelect({
+      period: selectedPeriod,
+      theme: [...selectedThemes],
+      spot: isSelected ? removeList(selectedSpots, spot) : updateList(selectedSpots, spot)
+    });
+
+    isSelected
+      ? setSelectedSpots(removeList(selectedSpots, spot))
+      : setSelectedSpots(updateList(selectedSpots, spot));
   };
 
   return (

--- a/src/components/common/SortFilter/index.tsx
+++ b/src/components/common/SortFilter/index.tsx
@@ -5,12 +5,13 @@ import { sortOrder, SortType } from '~/types/course';
 
 interface SortFilterProps {
   onSort?: (value: SortType) => void; // TODO: 더미데이터 테스트 시점에 필수로 변경
+  initialValue?: SortType;
 }
 
 const defaultSortData = [{ value: sortOrder.DESC }, { value: sortOrder.POPULAR }];
 
-const SortFilter: React.FC<SortFilterProps> = ({ onSort }) => {
-  const [isSelected, setIsSelected] = useState<SortType>(sortOrder.DESC);
+const SortFilter: React.FC<SortFilterProps> = ({ onSort, initialValue }) => {
+  const [isSelected, setIsSelected] = useState<SortType>(initialValue || sortOrder.DESC);
 
   const handleClick = (value: SortType) => {
     setIsSelected(value);

--- a/src/pages/search/[keyword].tsx
+++ b/src/pages/search/[keyword].tsx
@@ -6,12 +6,16 @@ import React, { useEffect, useState } from 'react';
 import { PageContainer, Title } from '~/components/atom';
 import { SelectTags, SelectRegion, CourseList, SortFilter } from '~/components/common';
 import { CourseApi } from '~/service';
-import { RegionAndAll, SearchTagsValues } from '~/types';
+import { Period, RegionAndAll, SearchTagsValues, Spot, Theme } from '~/types';
 import { ICourseItem } from '~/types/course';
 
 const SearchedKeywordPage: NextPage = () => {
   const [loading, setLoading] = useState(true);
   const [courseList, setCourseList] = useState<ICourseItem[]>([]);
+  const [region, setRegion] = useState<RegionAndAll | null>(null);
+  const [period, setPeriod] = useState<Period | null>(null);
+  const [themes, setThemes] = useState<Theme[]>([]);
+  const [spots, setSpots] = useState<Spot[]>([]);
   const isSearched = courseList.length !== 0;
   const {
     query: { keyword }
@@ -19,7 +23,7 @@ const SearchedKeywordPage: NextPage = () => {
 
   const getCourseListByKeyword = async (keyword: string) => {
     try {
-      const response = await CourseApi.getCourses({ keyword });
+      const response = await CourseApi.getCourses({ keyword, size: 10, page: 0 });
       setCourseList(response.content);
     } catch (e) {
       console.error('리스트를 불러오지 못했어요.', e);
@@ -27,13 +31,14 @@ const SearchedKeywordPage: NextPage = () => {
   };
 
   const handleSelectRegion = async (region: RegionAndAll) => {
-    if (!isSearched) return;
-    console.log(region);
+    setRegion(region);
   };
 
   const handleSelectTags = async (data: SearchTagsValues) => {
-    if (!isSearched) return;
-    console.log(data);
+    const { period, theme, spot } = data;
+    setPeriod(period);
+    setThemes([...theme]);
+    setSpots([...spot]);
   };
 
   const handleSort = async () => {
@@ -44,9 +49,13 @@ const SearchedKeywordPage: NextPage = () => {
     setLoading(true);
     if (keyword && typeof keyword === 'string') {
       getCourseListByKeyword(keyword);
-      setLoading(false);
     }
+    setLoading(false);
   }, [keyword]);
+
+  useEffect(() => {
+    console.log(region, period, themes, spots);
+  }, [region, period, themes, spots]);
 
   return (
     <React.Fragment>

--- a/src/service/domains/course.ts
+++ b/src/service/domains/course.ts
@@ -1,6 +1,6 @@
 import Api from '~/service/core/Api';
-import { CourseFilter } from '~/types/course';
-import { ObjectToQuery } from '~/utils/converter';
+import { CourseFilter, CourseSearchParams } from '~/types/course';
+import { makeQueryString, ObjectToQuery } from '~/utils/converter';
 
 type CourseReadingType = {
   readonly placeId?: number;
@@ -73,25 +73,17 @@ class CourseApi extends Api {
     } */
   };
 
-  search = async (paramData: CourseReadingType) => {
-    /* try {
-      const response = await this.baseInstance.get(this.path, {
-        params: {
-          placeId: paramData.placeId,
-          keyword: paramData.keyword,
-          region: paramData.region,
-          spot: paramData.spot,
-          theme: paramData.theme,
-          page: paramData.page,
-          size: paramData.size,
-          sort: paramData.sort
-        }
-      });
-      console.log(response);
-      return response.data;
+  search = async (params: CourseSearchParams) => {
+    const queries = makeQueryString(params);
+    try {
+      const response = await this.baseInstance.get(`${this.path}${queries}`);
+      if (response.status === 200 || response.status === 204) {
+        return response.data;
+      }
+      throw new Error(`코스 목록 조회 오류, 상태코드 : ${response.status}`);
     } catch (e) {
       console.error(`코스 목록 조회 오류: ${e}`);
-    } */
+    }
   };
 
   searchBookmarked = async (paramData: CourseSearchBookmarked) => {

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,3 +1,5 @@
+import { Period, RegionAndAll, Spot, Theme } from '.';
+
 export interface ICourseItem {
   id: number;
   title: string;
@@ -30,3 +32,15 @@ export const sortOrder = {
 } as const;
 
 export type SortType = typeof sortOrder[keyof typeof sortOrder];
+
+export type CourseSearchParams = {
+  readonly placeId?: number;
+  readonly keyword?: string;
+  readonly period: Period | null;
+  readonly region?: RegionAndAll | null;
+  readonly spot?: Spot[];
+  readonly theme?: Theme[];
+  readonly page?: number;
+  readonly size?: number;
+  readonly sorting: SortType;
+};

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,3 +1,5 @@
+import { CourseSearchParams } from '~/types/course';
+
 export const ObjectToQuery = (obj: any) => {
   // any type 수정 예정
   return `?${Object.entries(obj)
@@ -12,3 +14,15 @@ export function updateList<T>(list: T[], item: T): T[] {
 export function removeList<T>(list: T[], item: T): T[] {
   return list.filter((listItem) => listItem !== item);
 }
+
+export const makeQueryString = (params: CourseSearchParams): string => {
+  return Object.entries(params).reduce((queryString, [key, value]) => {
+    if (Array.isArray(value) && value.length > 0) {
+      return queryString + `&${key}=${value.join(',')}`;
+    }
+    if (value) {
+      return queryString + `&${key}=${value}`;
+    }
+    return queryString;
+  }, '?');
+};

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -4,3 +4,11 @@ export const ObjectToQuery = (obj: any) => {
     .map((e) => e.join('='))
     .join('&')}`;
 };
+
+export function updateList<T>(list: T[], item: T): T[] {
+  return [...list, item];
+}
+
+export function removeList<T>(list: T[], item: T): T[] {
+  return list.filter((listItem) => listItem !== item);
+}


### PR DESCRIPTION
# ✅ 이슈번호
closes #102 

# 📌 구현 내역
## 설명

1. 검색페이지에서 필터링 로직을 구현했습니다.
2. 일단 `search/:keyword` 라우트로 만들었는데, 메인페이지에서 태그를 클릭해서 넘어왔을 때를 생각하니 역시 `search?&...`로만 가야하는게 맞는 것 같기도하고... 어렵네요 ㅜㅜ
3. 일단 태그클릭은 고려하지 않고 구현했습니다.

## 이미지

![filter](https://user-images.githubusercontent.com/64957267/183390711-34b34919-1b4a-47c6-b19c-e15293962768.gif)

