### PR TITLE
feat: DetailSidebar 좋아요/북마크 API 연결

### DIFF
--- a/src/components/common/DetailSidebar/index.tsx
+++ b/src/components/common/DetailSidebar/index.tsx
@@ -1,28 +1,27 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Icon, Text } from '~/components/atom';
-import { CourseApi, LikesApi } from '~/service';
+import { BookmarkApi, LikeApi } from '~/service';
 import theme from '~/styles/theme';
+import { CourseOrPlace } from '~/types';
 
 interface DetailSidebarProps {
   likes?: number;
+  id: number;
   defaultLiked?: boolean;
   defaultBookmarked?: boolean;
   isLoggedIn?: boolean;
+  type: CourseOrPlace;
 }
-/*
-  TODO: 
-  1. 코스와 장소페이지의 처리가 다르게 되도록 구현
-  2. API 완성될 경우 실제 요청 보내도록 처리
-
-*/
 
 const DetailSidebar = ({
   likes = 0,
+  id,
   defaultLiked,
   defaultBookmarked,
-  isLoggedIn
+  isLoggedIn,
+  type
 }: DetailSidebarProps) => {
   const [isLiked, setIsLiked] = useState(defaultLiked);
   const [isBookmarked, setIsBookmarked] = useState(defaultBookmarked);
@@ -34,9 +33,10 @@ const DetailSidebar = ({
       router.push('/login');
       return;
     }
-    // const result = await LikesApi.likeCourse(id);
-    setIsLiked(!isLiked);
-    setTotalLikes(isLiked ? totalLikes - 1 : totalLikes + 1);
+
+    const result = await LikeApi.like(id, type);
+    setIsLiked(result.isLiked);
+    setTotalLikes((oldLikes) => (result.isLiked ? oldLikes + 1 : oldLikes - 1));
   };
 
   const handleClickBookmark = async () => {
@@ -44,9 +44,15 @@ const DetailSidebar = ({
       router.push('/login');
       return;
     }
-    // const result = await LikesApi.likeCourse(id);
-    setIsBookmarked(!isBookmarked);
+    const result = await BookmarkApi.bookmark(id, type);
+    setIsBookmarked(result.isBookmarked);
   };
+
+  useEffect(() => {
+    setIsLiked(defaultLiked);
+    setIsBookmarked(defaultBookmarked);
+    // 로그인 유저의 데이터로 변경되었을 때를 위해 default값 감지
+  }, [defaultLiked, defaultBookmarked]);
 
   return (
     <Container>

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -25,9 +25,8 @@ const CourseDetail: NextPage = () => {
   */
   const { currentUser, isLoggedIn } = useUser();
   const [detailData, setDetailData] = useState<ICourseDetail | null>(null);
-  const [like, setLike] = useState<number>(0);
   const router = useRouter();
-  const courseId = router.query.id;
+  const courseId = Number(router.query.id);
 
   const getDetailInfo = async (courseId: number) => {
     if (isLoggedIn) {
@@ -38,7 +37,6 @@ const CourseDetail: NextPage = () => {
         return;
       }
       setDetailData(result);
-      setLike(result.likes);
     } else {
       const result = await CourseApi.read(courseId);
       if (!result) {
@@ -46,22 +44,19 @@ const CourseDetail: NextPage = () => {
         return;
       }
       setDetailData(result);
-      setLike(result.likes);
     }
   };
 
   useEffect(() => {
-    if (typeof courseId === 'string') {
-      if (!Number.isNaN(Number(courseId))) {
-        getDetailInfo(Number(courseId));
+    if (typeof router.query.id === 'string') {
+      if (!Number.isNaN(courseId)) {
+        getDetailInfo(courseId);
         return;
       }
 
       router.push('/');
-      return;
     }
-    // 의존성 추가 시 네트워크 요청 2번 함
-  }, [courseId, router]);
+  }, [courseId, isLoggedIn]);
 
   if (!detailData) {
     return null;
@@ -80,9 +75,9 @@ const CourseDetail: NextPage = () => {
           <CourseDetailHeader>
             <CourseTitle>
               <Title level={2} size="lg" fontWeight={700} block>
-                {detailData?.title}
+                {detailData.title}
               </Title>
-              {currentUser.user.id === detailData?.userId && (
+              {currentUser.user.id === detailData.userId && (
                 <HeaderButtons>
                   <button>수정</button>
                   <button>삭제</button>
@@ -91,11 +86,11 @@ const CourseDetail: NextPage = () => {
             </CourseTitle>
             <CourseDate>
               <Text color="gray">업로드한 날: {sliceDate(detailData.createdAt)}</Text>
-              <Text color="gray">마지막 수정한 날: {sliceDate(detailData?.updatedAt)}</Text>
+              <Text color="gray">마지막 수정한 날: {sliceDate(detailData.updatedAt)}</Text>
             </CourseDate>
 
             <Profile>
-              <Link href={`/userinfo/${detailData?.userId}`}>
+              <Link href={`/userinfo/${detailData.userId}`}>
                 <Avatar size={66} />
               </Link>
               <Text color="dark" fontWeight={500}>
@@ -106,11 +101,11 @@ const CourseDetail: NextPage = () => {
 
           <CourseDetails>
             <CourseOverview
-              themes={detailData?.themes}
-              period={detailData?.period}
-              region={detailData?.region}
-              courseCount={detailData?.places.length}
-              spots={detailData?.spots}
+              themes={detailData.themes}
+              period={detailData.period}
+              region={detailData.region}
+              courseCount={detailData.places.length}
+              spots={detailData.spots}
             />
 
             <TravelRoute>
@@ -123,16 +118,18 @@ const CourseDetail: NextPage = () => {
               <DetailTitle size="md" fontWeight={700}>
                 다녀온 코스
               </DetailTitle>
-              <CourseSlider places={detailData?.places} />
+              <CourseSlider places={detailData.places} />
             </TravelCourse>
-            <CourseDetailList places={detailData?.places} />
+            <CourseDetailList places={detailData.places} />
           </CourseDetails>
           <Comment />
           <DetailSidebar
-            likes={like}
-            defaultLiked={detailData?.isLiked}
-            defaultBookmarked={detailData?.isBookmarked}
+            likes={detailData.likes}
+            id={detailData.id}
+            defaultLiked={detailData.isLiked}
+            defaultBookmarked={detailData.isBookmarked}
             isLoggedIn={isLoggedIn}
+            type="course"
           />
         </PageContainer>
       </main>

--- a/src/pages/place/[postId].tsx
+++ b/src/pages/place/[postId].tsx
@@ -87,11 +87,14 @@ const PlaceDetailByPostId = ({ post }: Props) => {
 
       <main>
         <Container type="detail" style={{ position: 'relative' }}>
-          <DetailSidebar
-            likes={post.likeCount}
-            defaultLiked={post.liked}
-            defaultBookmarked={post.bookmarked}
-          />
+          {/* <DetailSidebar
+            likes={post.likes}
+            id={post.id}
+            defaultLiked={post.isLiked}
+            defaultBookmarked={post.isBookmarked}
+            isLoggedIn={isLoggedIn}
+            type="course"
+          /> */}
           <PostHeader>
             <Title level={1} size="lg" fontWeight={700} block>
               {post.name}

--- a/src/service/domains/bookmark.ts
+++ b/src/service/domains/bookmark.ts
@@ -1,16 +1,28 @@
 import Api from '~/service/core/Api';
+import { CourseOrPlace } from '~/types';
 
 class BookmarkApi extends Api {
   private path = '/bookmarks';
 
-  BookmarkCourse = async (courseId: number) => {
+  bookmarkCourse = async (courseId: number) => {
     const response = await this.authInstance.get(`${this.path}/courses/${courseId}`);
     return response.data;
   };
 
-  BookmarkPlace = async (placeId: number) => {
+  bookmarkPlace = async (placeId: number) => {
     const response = await this.authInstance.get(`${this.path}/places/${placeId}`);
     return response.data;
+  };
+
+  bookmark = async (id: number, type: CourseOrPlace) => {
+    switch (type) {
+      case 'course':
+        return await this.bookmarkCourse(id);
+      case 'place':
+        return await this.bookmarkPlace(id);
+      default:
+        return;
+    }
   };
 }
 

--- a/src/service/domains/bookmark.ts
+++ b/src/service/domains/bookmark.ts
@@ -1,0 +1,17 @@
+import Api from '~/service/core/Api';
+
+class BookmarkApi extends Api {
+  private path = '/bookmarks';
+
+  BookmarkCourse = async (courseId: number) => {
+    const response = await this.authInstance.get(`${this.path}/courses/${courseId}`);
+    return response.data;
+  };
+
+  BookmarkPlace = async (placeId: number) => {
+    const response = await this.authInstance.get(`${this.path}/places/${placeId}`);
+    return response.data;
+  };
+}
+
+export default new BookmarkApi();

--- a/src/service/domains/like.ts
+++ b/src/service/domains/like.ts
@@ -1,6 +1,7 @@
 import Api from '~/service/core/Api';
+import { LikeType } from '~/types/like';
 
-class LikesApi extends Api {
+class LikeApi extends Api {
   private path = '/likes';
 
   likeCourse = async (courseId: number) => {
@@ -12,6 +13,17 @@ class LikesApi extends Api {
     const response = await this.authInstance.get(`${this.path}/places/${placeId}`);
     return response.data;
   };
+
+  like = async (id: number, type: LikeType) => {
+    switch (type) {
+      case 'course':
+        return await this.likeCourse(id);
+      case 'place':
+        return await this.likePlace(id);
+      default:
+        return;
+    }
+  };
 }
 
-export default new LikesApi();
+export default new LikeApi();

--- a/src/service/domains/like.ts
+++ b/src/service/domains/like.ts
@@ -1,5 +1,5 @@
 import Api from '~/service/core/Api';
-import { LikeType } from '~/types/like';
+import { CourseOrPlace } from '~/types';
 
 class LikeApi extends Api {
   private path = '/likes';
@@ -14,7 +14,7 @@ class LikeApi extends Api {
     return response.data;
   };
 
-  like = async (id: number, type: LikeType) => {
+  like = async (id: number, type: CourseOrPlace) => {
     switch (type) {
       case 'course':
         return await this.likeCourse(id);

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -2,3 +2,4 @@ export { default as UserApi } from './domains/user';
 export { default as CourseApi } from './domains/course';
 export { default as PlaceApi } from './domains/place';
 export { default as LikesApi } from './domains/likes';
+export { default as BookmarkApi } from './domains/bookmark';

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,5 +1,5 @@
 export { default as UserApi } from './domains/user';
 export { default as CourseApi } from './domains/course';
 export { default as PlaceApi } from './domains/place';
-export { default as LikesApi } from './domains/likes';
+export { default as LikeApi } from './domains/like';
 export { default as BookmarkApi } from './domains/bookmark';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,3 +75,5 @@ export interface SearchTagsValues {
 export interface SearchCourseValues extends SearchTagsValues {
   region: Region;
 }
+
+export type CourseOrPlace = 'course' | 'place';

--- a/src/types/like.ts
+++ b/src/types/like.ts
@@ -1,0 +1,1 @@
+export type LikeType = 'course' | 'place';

--- a/src/types/like.ts
+++ b/src/types/like.ts
@@ -1,1 +1,0 @@
-export type LikeType = 'course' | 'place';


### PR DESCRIPTION
# ✅ 이슈번호
closes #109 

# 📌 구현 내역

## DetailSidebar 좋아요/북마크 API 연결 및 기능 구현

- 코스 상세 페이지에 연결 완료했습니다.
- 좋아요/북마크 클릭하여 업데이트 될 때 DetailSidebar 컴포넌트에만 리렌더링 하면 될 것 같아서
부모 컴포넌트에 값을 전달하진 않았습니다.
- 좋아요 클릭 시 count값은 처음에 데이터로 받았던 값에서 증가/감소 됩니다. 
- 장소 페이지에서 사용 시 아래와 같이 사용 가능합니다.
```
      <DetailSidebar
            likes={detailData.likes} 
            id={detailData.id}
            defaultLiked={detailData.isLiked}
            defaultBookmarked={detailData.isBookmarked}
            isLoggedIn={isLoggedIn} // 현재 로그인 상태
            type="course" // place로 변경하기
          />
```
