### PR TITLE
feat: ImageUpload 컴포넌트 구현

### DIFF
--- a/src/components/common/ImageUpload/index.tsx
+++ b/src/components/common/ImageUpload/index.tsx
@@ -1,0 +1,40 @@
+import React, { RefObject } from 'react';
+
+interface IImageUpload {
+  onImageUpload: (file: File) => void;
+  imageRef: RefObject<HTMLInputElement>;
+  labelId?: string;
+}
+
+const ImageUpload = ({ onImageUpload, imageRef, labelId }: IImageUpload) => {
+  const inputRef = imageRef;
+  const isImageFile = (file: File) => file.type.match('image/.*');
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files === null) return;
+    if (e.target.files.length === 0) return;
+
+    const firstFile = e.target.files[0];
+    if (!isImageFile(firstFile)) {
+      alert('이미지 파일이 아닙니다');
+
+      e.target.value = '';
+      return;
+    }
+
+    onImageUpload(firstFile);
+  };
+  return (
+    <>
+      <input
+        ref={inputRef}
+        id={labelId}
+        style={{ display: 'none' }}
+        type="file"
+        accept="image/*"
+        onChange={handleChange}
+      />
+    </>
+  );
+};
+
+export default ImageUpload;

--- a/src/components/domain/CourseCreate/PlaceInformation.tsx
+++ b/src/components/domain/CourseCreate/PlaceInformation.tsx
@@ -3,7 +3,8 @@ import { MutableRefObject, ReactNode, SetStateAction, useRef, useState } from 'r
 import { Text } from '~/components/atom';
 import theme from '~/styles/theme';
 import Textarea from '~/components/atom/Textarea';
-
+import Image from 'next/image';
+import ImageUpload from '~/components/common/ImageUpload';
 interface IPlace {
   id: number;
   lat: number;
@@ -35,7 +36,7 @@ const PlaceInformation = ({
   placeImageRef,
   onChangeThumnail
 }: IPlaceInformation) => {
-  const [file, setFile] = useState('');
+  const [file, setFile] = useState<File | string>('');
   const [previewUrl, setPreviewUrl] = useState('');
   const [isRecommended, setIsRecommended] = useState(false);
   const imageRef = useRef(null);
@@ -49,16 +50,15 @@ const PlaceInformation = ({
     e.target.value = !isRecommended;
     setIsRecommended(!isRecommended);
   };
+
   // any는 추후 제거하겠습니다!
-  const handleFileOnChange = (e: any) => {
-    e.preventDefault();
+  const handleFileOnChange = (imageFile: File) => {
     const reader = new FileReader();
-    const file = e.target.files[0];
     reader.onloadend = () => {
-      setFile(file);
+      setFile(imageFile);
       setPreviewUrl(reader.result as SetStateAction<string>);
     };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(imageFile);
     const { current } = imageRef as unknown as MutableRefObject<HTMLElement>;
     if (current !== null) {
       current.style.display = 'none';
@@ -69,10 +69,11 @@ const PlaceInformation = ({
     profile_preview = (
       // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
       <>
-        <img
+        <Image
           style={{ width: '830px', height: '500px', zIndex: '100', borderRadius: '8px' }}
           className="profile_preview"
           src={previewUrl}
+          layout="fill"
         />
         <ThumbnailButton
           name={children?.toString()}
@@ -110,14 +111,10 @@ const PlaceInformation = ({
             {place.roadAddressName}
           </Text>
           <ImageUploadWrapper>
-            <input
-              type="file"
-              id={imageId}
-              name="imgFile"
-              accept="image/jpg,impge/png,image/jpeg,image/gif"
-              style={{ display: 'none' }}
-              onChange={handleFileOnChange}
-              ref={placeImageRef}
+            <ImageUpload
+              onImageUpload={handleFileOnChange}
+              imageRef={placeImageRef}
+              labelId={imageId}
             />
             <FileUploadWrapper ref={imageRef}>
               <label htmlFor={imageId}>


### PR DESCRIPTION
# ✅ 이슈번호
closes #113 

# 📌 구현 내역
## 설명
등록한 이미지 파일을 반환해주는 ImageUpload 컴포넌트를 구현했습니다.

### 사용페이지
- 유저 정보
- 코스 등록
- 코스 수정

### Props
```
onImageUpload: 이미지 업로드 후처리 핸들러 전달
imageRef: 이미지 객체를 가리키는 useRef전달
labelId: 페이지의 label과 컴포넌트 input의 id를 매칭시켜주는 id
```
### 사용 예시
```js
<ProfileAvatar size={143} src={previewImage} />
<ImageUpload
  onImageUpload={handleFileOnChange}
  imageRef={profileImageRef}
  labelId={imageId}
/>
{isMyPage && (
  <EditButton>
    <label htmlFor={imageId} style={{ cursor: 'pointer' }}>
      <Icon size={16} name="pencil" block />
    </label>
  </EditButton>
)}
```
## 이미지

### before
![image](https://user-images.githubusercontent.com/15838144/183404233-55dabc3d-5e81-4b7f-95fe-ac34c1894022.png)



### after
![image](https://user-images.githubusercontent.com/15838144/183404089-d44f9f1f-027b-4998-83f0-b9d0d6133e99.png)
