### PR TITLE
feat: ProfileCard 컴포넌트 API 연결 (프로필이미지 변경, 유저정보 표시)

### DIFF
--- a/src/components/common/ImageUpload/index.tsx
+++ b/src/components/common/ImageUpload/index.tsx
@@ -1,0 +1,40 @@
+import React, { RefObject } from 'react';
+
+interface IImageUpload {
+  onImageUpload: (file: File) => void;
+  imageRef: RefObject<HTMLInputElement>;
+  labelId?: string;
+}
+
+const ImageUpload = ({ onImageUpload, imageRef, labelId }: IImageUpload) => {
+  const inputRef = imageRef;
+  const isImageFile = (file: File) => file.type.match('image/.*');
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files === null) return;
+    if (e.target.files.length === 0) return;
+
+    const firstFile = e.target.files[0];
+    if (!isImageFile(firstFile)) {
+      alert('이미지 파일이 아닙니다');
+
+      e.target.value = '';
+      return;
+    }
+
+    onImageUpload(firstFile);
+  };
+  return (
+    <>
+      <input
+        ref={inputRef}
+        id={labelId}
+        style={{ display: 'none' }}
+        type="file"
+        accept="image/*"
+        onChange={handleChange}
+      />
+    </>
+  );
+};
+
+export default ImageUpload;

--- a/src/components/domain/CourseCreate/PlaceInformation.tsx
+++ b/src/components/domain/CourseCreate/PlaceInformation.tsx
@@ -3,7 +3,8 @@ import { MutableRefObject, ReactNode, SetStateAction, useRef, useState } from 'r
 import { Text } from '~/components/atom';
 import theme from '~/styles/theme';
 import Textarea from '~/components/atom/Textarea';
-
+import Image from 'next/image';
+import ImageUpload from '~/components/common/ImageUpload';
 interface IPlace {
   id: number;
   lat: number;
@@ -35,7 +36,7 @@ const PlaceInformation = ({
   placeImageRef,
   onChangeThumnail
 }: IPlaceInformation) => {
-  const [file, setFile] = useState('');
+  const [file, setFile] = useState<File | string>('');
   const [previewUrl, setPreviewUrl] = useState('');
   const [isRecommended, setIsRecommended] = useState(false);
   const imageRef = useRef(null);
@@ -49,16 +50,15 @@ const PlaceInformation = ({
     e.target.value = !isRecommended;
     setIsRecommended(!isRecommended);
   };
+
   // any는 추후 제거하겠습니다!
-  const handleFileOnChange = (e: any) => {
-    e.preventDefault();
+  const handleFileOnChange = (imageFile: File) => {
     const reader = new FileReader();
-    const file = e.target.files[0];
     reader.onloadend = () => {
-      setFile(file);
+      setFile(imageFile);
       setPreviewUrl(reader.result as SetStateAction<string>);
     };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(imageFile);
     const { current } = imageRef as unknown as MutableRefObject<HTMLElement>;
     if (current !== null) {
       current.style.display = 'none';
@@ -69,10 +69,11 @@ const PlaceInformation = ({
     profile_preview = (
       // eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
       <>
-        <img
+        <Image
           style={{ width: '830px', height: '500px', zIndex: '100', borderRadius: '8px' }}
           className="profile_preview"
           src={previewUrl}
+          layout="fill"
         />
         <ThumbnailButton
           name={children?.toString()}
@@ -110,14 +111,10 @@ const PlaceInformation = ({
             {place.roadAddressName}
           </Text>
           <ImageUploadWrapper>
-            <input
-              type="file"
-              id={imageId}
-              name="imgFile"
-              accept="image/jpg,impge/png,image/jpeg,image/gif"
-              style={{ display: 'none' }}
-              onChange={handleFileOnChange}
-              ref={placeImageRef}
+            <ImageUpload
+              onImageUpload={handleFileOnChange}
+              imageRef={placeImageRef}
+              labelId={imageId}
             />
             <FileUploadWrapper ref={imageRef}>
               <label htmlFor={imageId}>

--- a/src/components/domain/UserInfo/ProfileCard/index.tsx
+++ b/src/components/domain/UserInfo/ProfileCard/index.tsx
@@ -6,7 +6,7 @@ import { useUser } from '~/hooks/useUser';
 import theme from '~/styles/theme';
 
 interface ProfileCardProps {
-  profileImage: string;
+  profileImage: string | null;
   nickname: string;
   email: string;
   onClickAction: (value: string) => void;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -19,7 +19,7 @@ export const useUser = () => {
   const updateUser = async (token: string) => {
     setCurrentUser({ ...currentUser, isLoading: true });
 
-    const response = await UserApi.getUser();
+    const response = await UserApi.getMyInfo();
     console.log(response, '★update User★');
     setCurrentUser({
       accessToken: token,

--- a/src/service/domains/user.ts
+++ b/src/service/domains/user.ts
@@ -51,6 +51,15 @@ class UserApi extends Api {
     const response = await this.baseInstance.get(`${this.path}/${userId}`);
     return response.data;
   };
+
+  changeProfileImage = async (data: FormData) => {
+    const response = await this.authInstance.put(`${this.path}/profile`, data, {
+      headers: {
+        'Content-Type': 'multipart/form-data'
+      }
+    });
+    return response;
+  };
 }
 
 export default new UserApi();

--- a/src/service/domains/user.ts
+++ b/src/service/domains/user.ts
@@ -42,8 +42,13 @@ class UserApi extends Api {
     return response;
   };
 
-  getUser = async () => {
+  getMyInfo = async () => {
     const response = await this.authInstance.get(`${this.path}`);
+    return response.data;
+  };
+
+  getUser = async (userId: number) => {
+    const response = await this.baseInstance.get(`${this.path}/${userId}`);
     return response.data;
   };
 }


### PR DESCRIPTION
# ✅ 이슈번호
closes #121 

# 📌 구현 내역
- ProfileCard 컴포넌트에 유저 정보 api 연결하여 해당 유저의 게시물/댓글/북마크 개수를 볼 수 있습니다.
- api에서 email이 전달이 안되어 일단 임시로 birth값을 보여줍니다. (api 수정 시 변경될 예정)

## 프로필 이미지 변경
- ImageUpload 컴포넌트를 사용하여 프로필 이미지와 API를 연결했습니다.
- 현재 1MB 이상의 이미지를 등록할 경우 서버에서 에러를 반환하는데
이 부분은 사용자에게 이미지를 받고 클라이언트에서 이미지를 압축하여 올리는 방식으로 개선해야 할 것 같습니다.

![profileCard](https://user-images.githubusercontent.com/81489300/183539197-9e2b123c-1cc8-4ddd-afbd-3f28af513216.gif)

