### PR TITLE
feat: 비밀번호 수정 페이지 구현

### DIFF
--- a/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
+++ b/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
@@ -20,7 +20,7 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
   const [passwordError, setPasswordError] = useState('');
   const [passwordCheckError, setPasswordCheckError] = useState('');
 
-  const { values, handleChange, handleSubmit, errors } = useFormik({
+  const { values, handleChange, handleSubmit, errors, touched } = useFormik({
     initialValues,
     validationSchema: ValidationRules,
     onSubmit: (data: UserPasswordFormValues) => {
@@ -28,8 +28,12 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
     }
   });
 
-  const handleBlur = () => {
+  const handleBlurPassword = () => {
     setPasswordError(errors.password || '');
+    values.passwordCheck && setPasswordCheckError(errors.passwordCheck || '');
+  };
+
+  const handleBlurPasswordCheck = () => {
     setPasswordCheckError(errors.passwordCheck || '');
   };
 
@@ -63,7 +67,7 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
           placeholder="새 비밀번호를 입력해주세요."
           value={values.password}
           onChange={handleChange}
-          onBlur={handleBlur}
+          onBlur={handleBlurPassword}
         />
       </Field>
       {passwordError && (
@@ -81,7 +85,7 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
           placeholder="새 비밀번호를 다시 입력해주세요."
           value={values.passwordCheck}
           onChange={handleChange}
-          onBlur={handleBlur}
+          onBlur={handleBlurPasswordCheck}
         />
       </Field>
       {passwordCheckError && (

--- a/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
+++ b/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
@@ -1,0 +1,134 @@
+import styled from '@emotion/styled';
+import { useFormik } from 'formik';
+import React, { useMemo, useState } from 'react';
+import { Button, Input } from '~/components/atom';
+import { ErrorMessage } from '~/components/common';
+import { UserPasswordFormValues } from '~/types/user';
+import { ValidationRules } from './rules';
+
+const initialValues: UserPasswordFormValues = {
+  oldPassword: '',
+  password: '',
+  passwordCheck: ''
+};
+
+interface PasswordChangeFormProps {
+  onSubmit: (data: UserPasswordFormValues) => void;
+}
+
+const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProps) => {
+  const [passwordError, setPasswordError] = useState('');
+  const [passwordCheckError, setPasswordCheckError] = useState('');
+
+  const { values, handleChange, handleSubmit, errors } = useFormik({
+    initialValues,
+    validationSchema: ValidationRules,
+    onSubmit: (data: UserPasswordFormValues) => {
+      onSubmitAction && onSubmitAction(data);
+    }
+  });
+
+  const handleBlur = () => {
+    setPasswordError(errors.password || '');
+    setPasswordCheckError(errors.passwordCheck || '');
+  };
+
+  const submitButtonDisabled = useMemo(() => {
+    return (
+      Object.values(values).some((value) => value.length === 0) ||
+      Object.entries(errors).some((error) => !!error)
+    );
+  }, [values, errors]);
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Field>
+        <label htmlFor="oldPassword">현재 비밀번호</label>
+        <Input
+          type="password"
+          style={{ width: '437px', marginRight: '10px' }}
+          name="oldPassword"
+          placeholder="현재 비밀번호를 입력해주세요."
+          value={values.oldPassword}
+          onChange={handleChange}
+          required
+        />
+      </Field>
+      <Field>
+        <label htmlFor="password">새 비밀번호</label>
+        <Input
+          type="password"
+          style={{ width: '437px', marginRight: '10px' }}
+          name="password"
+          placeholder="새 비밀번호를 입력해주세요."
+          value={values.password}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+      </Field>
+      {passwordError && (
+        <Error>
+          <ErrorMessage message={passwordError} />
+        </Error>
+      )}
+
+      <Field>
+        <label htmlFor="passwordCheck">새 비밀번호 확인</label>
+        <Input
+          type="password"
+          style={{ width: '437px', marginRight: '10px' }}
+          name="passwordCheck"
+          placeholder="새 비밀번호를 다시 입력해주세요."
+          value={values.passwordCheck}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+      </Field>
+      {passwordCheckError && (
+        <Error>
+          <ErrorMessage message={passwordCheckError} />
+        </Error>
+      )}
+
+      <Button
+        type="submit"
+        size="md"
+        width={195}
+        style={{ marginLeft: 150 }}
+        disabled={submitButtonDisabled}
+      >
+        내 정보 수정
+      </Button>
+    </Form>
+  );
+};
+
+export default PasswordChangeForm;
+
+const Form = styled.form`
+  margin-top: 50px;
+  > button {
+    margin-top: 30px;
+  }
+`;
+
+const Field = styled.div`
+  box-sizing: border-box;
+  height: 70px;
+  display: flex;
+  align-items: center;
+  > :first-of-type {
+    width: 150px;
+    font-weight: 500;
+  }
+
+  input {
+    &::placeholder {
+      font-weight: 400;
+    }
+  }
+`;
+
+const Error = styled.div`
+  margin-left: 160px;
+`;

--- a/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
+++ b/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
@@ -20,7 +20,7 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
   const [passwordError, setPasswordError] = useState('');
   const [passwordCheckError, setPasswordCheckError] = useState('');
 
-  const { values, handleChange, handleSubmit, errors, touched } = useFormik({
+  const { values, handleChange, handleSubmit, errors } = useFormik({
     initialValues,
     validationSchema: ValidationRules,
     onSubmit: (data: UserPasswordFormValues) => {

--- a/src/components/domain/UserInfo/PasswordChangeForm/rules.ts
+++ b/src/components/domain/UserInfo/PasswordChangeForm/rules.ts
@@ -1,0 +1,33 @@
+import { object, string, ref, ObjectSchema } from 'yup';
+import { Assign, ObjectShape } from 'yup/lib/object';
+import StringSchema, { RequiredStringSchema } from 'yup/lib/string';
+import { AnyObject } from 'yup/lib/types';
+
+const MESSAGE = {
+  password: '비밀번호는 영문, 숫자, 특수문자를 포함한 8~15자로 설정해주세요.',
+  passwordCheck: '동일한 비밀번호가 아니에요.'
+};
+
+const VALIDATION = {
+  password: /(?=.*\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&*()]).{8,15}/
+};
+
+interface SchemaInterface {
+  password: RequiredStringSchema<string | undefined, AnyObject>;
+  passwordCheck: StringSchema<string | undefined, AnyObject, string | undefined>;
+}
+
+export const ValidationRules: ObjectSchema<Assign<ObjectShape, SchemaInterface>> = object().shape({
+  oldPassword: string().required('현재 비밀번호를 입력해주세요.'),
+  password: string()
+    .min(8, MESSAGE.password)
+    .max(15, MESSAGE.password)
+    .matches(VALIDATION.password, MESSAGE.password)
+    .required('비밀번호를 입력해주세요.'),
+  passwordCheck: string()
+    .required('비밀번호를 한번 더 입력해주세요.')
+    .when('password', {
+      is: (password: string) => (password && password.length > 0 ? true : false),
+      then: string().oneOf([ref('password')], MESSAGE.passwordCheck)
+    })
+});

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -3,24 +3,34 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
-import { Button, PageContainer, Text, Title } from '~/components/atom';
+import { PageContainer, Title } from '~/components/atom';
+import PasswordChangeForm from '~/components/domain/UserInfo/PasswordChangeForm';
 import { useUser } from '~/hooks/useUser';
 import theme from '~/styles/theme';
+import { UserPasswordFormValues } from '~/types/user';
 
 const UserinfoEdit: NextPage = () => {
   const { currentUser } = useUser();
   const router = useRouter();
   const userId = Number(router.query.id);
 
+  const handleSubmit = async (data: UserPasswordFormValues) => {
+    console.log(data);
+  };
+
   useEffect(() => {
+    if (currentUser.isLoading) {
+      return;
+    }
+
     if (typeof router.query.id === 'string') {
-      if (!currentUser.isLoading && currentUser.user.id !== userId) {
+      if (currentUser.user.id !== userId) {
         alert('잘못된 요청입니다.');
         router.push('/');
         return;
       }
     }
-  }, [currentUser, userId, router]);
+  }, [currentUser]);
 
   if (currentUser.user.id !== userId) {
     return null;
@@ -38,35 +48,7 @@ const UserinfoEdit: NextPage = () => {
         <PageContainer>
           <Container>
             <Title>비밀번호 변경</Title>
-            <Form>
-              <FormItem>
-                <FormTitle>
-                  <Text>현재 비밀번호</Text>
-                </FormTitle>
-                <FormGroup>
-                  <input type="password" name="password" />
-                </FormGroup>
-              </FormItem>
-              <FormItem>
-                <FormTitle>
-                  <Text>새 비밀번호</Text>
-                </FormTitle>
-                <FormGroup>
-                  <input type="password" name="newPassword" />
-                </FormGroup>
-              </FormItem>
-              <FormItem>
-                <FormTitle>
-                  <Text>새 비밀번호 확인</Text>
-                </FormTitle>
-                <FormGroup>
-                  <input type="password" name="newPasswordConfirm" />
-                </FormGroup>
-              </FormItem>
-              <Button size="md" width={195} style={{ marginLeft: 150 }}>
-                내 정보 수정
-              </Button>
-            </Form>
+            <PasswordChangeForm onSubmit={handleSubmit} />
           </Container>
         </PageContainer>
       </main>

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -23,12 +23,15 @@ const UserinfoEdit: NextPage = () => {
       if (response.status === 200) {
         console.log('비밀번호 변경 성공');
         console.log(response);
+        // TODO- 비밀번호 변경 성공 시
+        // 1. 다시 로그인을 시킬 것인지 말 것인지
+        // 2. 페이징을 어떻게 할 것인지
         return;
       }
       console.error('비밀번호 변경에 실패했어요.');
     } catch (e: any) {
       const { response } = e;
-
+      // Api 에러 픽스 시 예외처리
       if (response.status === 400) {
         console.log('비밀번호가 틀렸어요.');
         console.log(response);

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -17,34 +17,26 @@ const UserinfoEdit: NextPage = () => {
 
   const handleSubmit = async (data: UserPasswordFormValues) => {
     const { oldPassword, password: newPassword } = data;
-    console.log(data);
     try {
       const response = await UserApi.changePassword({ oldPassword, newPassword });
       if (response.status === 200) {
-        console.log('비밀번호 변경 성공');
-        console.log(response);
-        // TODO- 비밀번호 변경 성공 시
-        // 1. 다시 로그인을 시킬 것인지 말 것인지
-        // 2. 페이징을 어떻게 할 것인지
+        // 다시 로그인 시키지 않고 유저 정보 페이지로 돌려보낸다.
+        window.alert('비밀번호 변경 성공!');
+        router.push(`/userinfo/${userId}`);
         return;
       }
-      console.error('비밀번호 변경에 실패했어요.');
     } catch (e: any) {
       const { response } = e;
-      // Api 에러 픽스 시 예외처리
       if (response.status === 400) {
-        console.log('비밀번호가 틀렸어요.');
-        console.log(response);
+        window.alert('현재 비밀번호가 올바르지 않습니다.');
         return;
       }
 
       if (response.status === 409) {
-        console.log('동일한 비밀번호입니다.');
-        console.log(response);
+        window.alert('동일한 비밀번호로는 변경할 수 없어요.');
         return;
       }
-
-      console.log(response);
+      console.error(e);
     }
   };
 

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from 'react';
 import { PageContainer, Title } from '~/components/atom';
 import PasswordChangeForm from '~/components/domain/UserInfo/PasswordChangeForm';
 import { useUser } from '~/hooks/useUser';
+import { UserApi } from '~/service';
 import theme from '~/styles/theme';
 import { UserPasswordFormValues } from '~/types/user';
 
@@ -15,22 +16,44 @@ const UserinfoEdit: NextPage = () => {
   const userId = Number(router.query.id);
 
   const handleSubmit = async (data: UserPasswordFormValues) => {
+    const { oldPassword, password: newPassword } = data;
     console.log(data);
+    try {
+      const response = await UserApi.changePassword({ oldPassword, newPassword });
+      if (response.status === 200) {
+        console.log('비밀번호 변경 성공');
+        console.log(response);
+        return;
+      }
+      console.error('비밀번호 변경에 실패했어요.');
+    } catch (e: any) {
+      const { response } = e;
+
+      if (response.status === 400) {
+        console.log('비밀번호가 틀렸어요.');
+        console.log(response);
+        return;
+      }
+
+      if (response.status === 409) {
+        console.log('동일한 비밀번호입니다.');
+        console.log(response);
+        return;
+      }
+
+      console.log(response);
+    }
   };
 
   useEffect(() => {
-    if (currentUser.isLoading) {
-      return;
-    }
-
     if (typeof router.query.id === 'string') {
-      if (currentUser.user.id !== userId) {
+      if (!currentUser.isLoading && currentUser.user.id !== userId) {
         alert('잘못된 요청입니다.');
         router.push('/');
         return;
       }
     }
-  }, [currentUser]);
+  }, [currentUser, router, userId]);
 
   if (currentUser.user.id !== userId) {
     return null;

--- a/src/service/domains/user.ts
+++ b/src/service/domains/user.ts
@@ -60,6 +60,11 @@ class UserApi extends Api {
     });
     return response;
   };
+
+  changePassword = async (bodyData: { oldPassword: string; newPassword: string }) => {
+    const response = await this.authInstance.put(`${this.path}/password`, bodyData);
+    return response;
+  };
 }
 
 export default new UserApi();

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -20,3 +20,9 @@ export interface UserInfo {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface UserPasswordFormValues {
+  oldPassword: string;
+  password: string;
+  passwordCheck: string;
+}


### PR DESCRIPTION
# ✅ 이슈번호
closes #126 

# 📌 구현 내역
## 설명

비밀번호 수정 페이지를 구현했습니다. 현재 api에 버그가 있습니다.
1. "수정"은 잘됩니다.
2. 그런데 일단 한번 수정하면 이 후 로그인도 안되고 로그인도 안되니... 다른 모든 로직이 불통이 됩니다. (500에러) 다른 분들은 테스트 하지 말아주세요... 왠지 토큰관련 로직에 문제가 있는 것 같은데 이 부분 키드에게 요청했고 내일 다른 분들께 여쭤볼 필요가 있다고 하셔서 당장 처리는 안될 듯 합니다.
3. 현재 보시는 이미지는 이미 수정을 한번해서(?) 500에러가 나오고 있는 상황입니다. 일단 UI 부분만 봐주시면 감사하겠습니다.

## 이미지

![password](https://user-images.githubusercontent.com/64957267/183700004-728cb93f-8ff5-496e-b522-a5c5789392a8.gif)

