### PR TITLE
ui: PageContainer 크기 수정 및 style 변경

### DIFF
--- a/public/assets/icons/search-blue.svg
+++ b/public/assets/icons/search-blue.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 21L16.65 16.65M19 11C19 15.4183 15.4183 19 11 19C6.58172 19 3 15.4183 3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11Z" stroke="#509FFB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/atom/Button/index.tsx
+++ b/src/components/atom/Button/index.tsx
@@ -102,8 +102,8 @@ const buttonStyle: buttonStyleInterface = {
 
 const buttonSize: buttonStyleInterface = {
   sm: `
-    padding: 8px 20px;
-    font-size: 20px;
+    padding: 10px 20px;
+    font-size: 18px;
   `,
   md: `
     padding: 16px 22px;
@@ -111,7 +111,7 @@ const buttonSize: buttonStyleInterface = {
   `,
   lg: `
     padding: 20px 45px;
-    font-size: 24px;
+    font-size: 22px;
   `
 };
 
@@ -133,7 +133,7 @@ const StyledButton = styled.button<ButtonInterface>`
   font-size: ${({ fontSize }) => (fontSize ? `${fontSize}px` : '')};
 
   border-radius: 5px;
-  font-weight: 600;
+  font-weight: 500;
   transition: all 0.1s;
 
   &:disabled {

--- a/src/components/atom/Icon/types.ts
+++ b/src/components/atom/Icon/types.ts
@@ -11,6 +11,7 @@ export const ICON_URLS = {
   heartInactive: '/assets/icons/heart-inactive.svg',
   share: '/assets/icons/share.svg',
   search: '/assets/icons/search.svg',
+  searchBlue: '/assets/icons/search-blue.svg',
   close: '/assets/icons/close.svg',
   plus: '/assets/icons/plus.svg',
   pencil: '/assets/icons/pencil.svg',

--- a/src/components/atom/PageContainer/index.tsx
+++ b/src/components/atom/PageContainer/index.tsx
@@ -20,6 +20,6 @@ const PageContainer = ({ type = 'main', children, ...props }: PageContainer) => 
 export default PageContainer;
 
 const Container = styled.div<{ type: LayoutType }>`
-  width: ${({ type }) => (type === 'main' ? '1156px' : '940px')};
+  width: ${({ type }) => (type === 'main' ? '1156px' : '796px')};
   margin: 0 auto;
 `;

--- a/src/components/domain/home/MainCategoryTitle.tsx
+++ b/src/components/domain/home/MainCategoryTitle.tsx
@@ -11,7 +11,7 @@ const MainCategoryTitle = ({ name }: MainCategoryTitleProps) => {
       <Title size="md" fontWeight={700}>
         {name}
       </Title>
-      <Icon name="arrow" size={25} />
+      <MoveIcon name="arrow" size={25} block />
     </Container>
   );
 };
@@ -20,4 +20,11 @@ export default MainCategoryTitle;
 
 const Container = styled.div`
   margin-bottom: 30px;
+  display: flex;
+  align-items: center;
+`;
+
+const MoveIcon = styled(Icon)`
+  margin-left: 6px;
+  margin-top: 2px;
 `;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { FormEvent, ReactElement, useEffect, useRef, useState } from 'react';
-import { Button, Link, PageContainer, Image } from '~/components/atom';
+import { Button, Link, PageContainer, Image, Icon } from '~/components/atom';
 import { CourseList, PlaceList } from '~/components/common';
 import Layout from '~/components/common/Layout';
 import MainCategoryTitle from '~/components/domain/home/MainCategoryTitle';
@@ -56,13 +56,14 @@ const HomePage = () => {
         <PageContainer>
           <SearchArea>
             <Image width={550} src="/assets/search-img.png" alt="여행할 땐 이곳저곳" />
-            <form onSubmit={handleSearch}>
+            <MainSearchForm onSubmit={handleSearch}>
+              <SearchIcon name="searchBlue" size={30} />
               <MainSearchInput
                 type="text"
                 placeholder="지역, 장소를 검색해보세요."
                 ref={mainSearchInputRef}
               />
-            </form>
+            </MainSearchForm>
             <Tags>
               <Button buttonType="tag">#힐링</Button>
               <Button buttonType="tag">#이쁜카페</Button>
@@ -101,6 +102,7 @@ HomePage.getLayout = function getLayout(page: ReactElement) {
 };
 
 const { backgroundLightGray, mainColor } = theme.color;
+const { basicShadow } = theme.shadow;
 
 const SearchArea = styled.div`
   display: flex;
@@ -108,21 +110,40 @@ const SearchArea = styled.div`
   align-items: center;
   padding-top: 90px;
 `;
-const MainSearchInput = styled.input`
-  width: 690px;
-  height: 80px;
+
+const MainSearchForm = styled.div`
   margin-top: 20px;
-  padding: 24px;
+  box-shadow: ${basicShadow};
+  border-radius: 8px;
+  position: relative;
+`;
+
+const SearchIcon = styled(Icon)`
+  position: absolute;
+  top: 26px;
+  left: 22px;
+`;
+
+const MainSearchInput = styled.input`
+  width: 640px;
+  height: 80px;
+
+  padding: 20px 24px 20px 66px;
   font-size: 24px;
-  color: ${mainColor};
+  color: black;
   border: 1px solid ${mainColor};
   border-radius: 8px;
   background-color: #f1f7ff;
   box-sizing: border-box;
-  box-shadow: 0px 2px 4px 1px rgb(0 0 0 / 5%); // TODO :shadow 종류별로 파일 나누기
+  transition: box-shadow 0.1s;
 
   &::placeholder {
     color: ${mainColor};
+  }
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0px 0px 0px 1px ${mainColor};
   }
 `;
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -14,7 +14,7 @@ const theme = {
     fontRed: '#ff3f3f'
   },
   shadow: {
-    basicShadow: '0px 2px 4px 1px rgb (0 0 0 / 5%)'
+    basicShadow: '0px 2px 4px 1px rgb(0 0 0 / 5%)'
   }
 };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,8 +13,8 @@ export const FONT_SIZES = {
 
 export const TITLE_SIZES = {
   sm: 24,
-  md: 32,
-  lg: 40
+  md: 28,
+  lg: 36
 };
 
 export const FONT_COLORS: { [key: string]: string } = {


### PR DESCRIPTION
# ✅ 이슈번호
closes #136 

# 📌 구현 내역


- PageContainer의 detail props로 받은 레이아웃의 가로너비가 940->796으로 변경했습니다.
: 작업된 페이지에서 width값 px로 고정해놓으신 경우 한번 확인 부탁드려요!

- 메인페이지 검색 창 focus시 style 추가하고 크기 조정했습니다.
- title sm, md, lg 로 사이즈 지정되어있던 부분 전부 4px씩 조정했습니다.
: 혹시나 직접 size=?px과 같은 형태로 작성하신 분들은 직접 조정이 필요할 듯 합니다.
