### PR TITLE
refactor: 회원가입 폼 리팩터링

### DIFF
--- a/src/components/domain/SignupForm/Fields/EmailField.tsx
+++ b/src/components/domain/SignupForm/Fields/EmailField.tsx
@@ -8,7 +8,7 @@ interface EmailFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   errors: string | undefined;
-  checkDuplicate: React.Dispatch<React.SetStateAction<boolean>>;
+  checkDuplicate?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkDuplicate }) => {
@@ -20,22 +20,21 @@ const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkD
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      checkDuplicate(false);
+      checkDuplicate && checkDuplicate(false);
       onChange(e);
     },
     [onChange, checkDuplicate]
   );
 
-  const disabled = useMemo(() => !!error || value.length === 0, [error, value]);
+  const disabled = useMemo(() => {
+    return !!error || value.length === 0;
+  }, [error, value]);
 
   const handleClickDuplicate = async () => {
-    if (disabled) {
-      return;
-    }
     try {
       await UserApi.emailCheck({ email: value });
       window.alert(`${value}는 사용가능한 메일입니다!`);
-      checkDuplicate(true);
+      checkDuplicate && checkDuplicate(true);
     } catch (e) {
       window.alert('이미 존재하는 메일이에요!');
     }
@@ -53,10 +52,10 @@ const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkD
         onChange={handleChange}
         onBlur={handleBlur}
       />
-      {error && <ErrorMessage message={error} />}
       <Button onClick={handleClickDuplicate} fontSize={FONT_SIZES.sm} disabled={disabled}>
         이메일 중복확인
       </Button>
+      {error && <ErrorMessage message={error} />}
     </Field>
   );
 };

--- a/src/components/domain/SignupForm/Fields/EmailField.tsx
+++ b/src/components/domain/SignupForm/Fields/EmailField.tsx
@@ -8,17 +8,10 @@ interface EmailFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   errors: string | undefined;
-  setInitDuplicateFn: () => void;
-  setDuplicateCheckFn: () => void;
+  checkDuplicate: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const EmailField: React.FC<EmailFieldProps> = ({
-  value,
-  onChange,
-  errors,
-  setInitDuplicateFn,
-  setDuplicateCheckFn
-}) => {
+const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkDuplicate }) => {
   const [error, setError] = useState(errors);
 
   const handleBlur = useCallback(() => {
@@ -27,10 +20,10 @@ const EmailField: React.FC<EmailFieldProps> = ({
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setInitDuplicateFn();
+      checkDuplicate(false);
       onChange(e);
     },
-    [onChange, setInitDuplicateFn]
+    [onChange, checkDuplicate]
   );
 
   const disabled = useMemo(() => !!error || value.length === 0, [error, value]);
@@ -42,7 +35,7 @@ const EmailField: React.FC<EmailFieldProps> = ({
     try {
       await UserApi.emailCheck({ email: value });
       window.alert(`${value}는 사용가능한 메일입니다!`);
-      setDuplicateCheckFn();
+      checkDuplicate(true);
     } catch (e) {
       window.alert('이미 존재하는 메일이에요!');
     }

--- a/src/components/domain/SignupForm/Fields/EmailField.tsx
+++ b/src/components/domain/SignupForm/Fields/EmailField.tsx
@@ -33,10 +33,10 @@ const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkD
   const handleClickDuplicate = async () => {
     try {
       await UserApi.emailCheck({ email: value });
-      window.alert(`${value}는 사용가능한 메일입니다!`);
+      window.alert(`${value}는 사용가능한 메일입니다.`);
       checkDuplicate && checkDuplicate(true);
     } catch (e) {
-      window.alert('이미 존재하는 메일이에요!');
+      window.alert('이미 존재하는 메일입니다.');
     }
   };
 

--- a/src/components/domain/SignupForm/Fields/NicknameField.tsx
+++ b/src/components/domain/SignupForm/Fields/NicknameField.tsx
@@ -8,16 +8,14 @@ interface NicknameFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   errors: string | undefined;
-  setInitDuplicateFn: () => void;
-  setDuplicateCheckFn: () => void;
+  checkDuplicate: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const NicknameField: React.FC<NicknameFieldProps> = ({
   value,
   onChange,
   errors,
-  setInitDuplicateFn,
-  setDuplicateCheckFn
+  checkDuplicate
 }) => {
   const [error, setError] = useState(errors);
 
@@ -27,10 +25,10 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setInitDuplicateFn();
+      checkDuplicate(false);
       onChange(e);
     },
-    [onChange, setInitDuplicateFn]
+    [onChange, checkDuplicate]
   );
 
   const disabled = useMemo(() => !!error || value.length === 0, [error, value]);
@@ -42,7 +40,7 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
     try {
       await UserApi.nicknameCheck({ nickname: value });
       window.alert(`${value}는 사용가능한 닉네임입니다!`);
-      setDuplicateCheckFn();
+      checkDuplicate(true);
     } catch (e) {
       window.alert('이미 존재하는 닉네임이에요!');
     }
@@ -52,7 +50,7 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
     <Field>
       <Label htmlFor="nickname" text="닉네임" />
       <Text size="xs" color="gray">
-        2~8자 이내의 닉네임을 입력해주세요.
+        특수문자가 포함되지 않는 2~8자리로 설정해주세요.
       </Text>
       <StyledField>
         <Input

--- a/src/components/domain/SignupForm/Fields/NicknameField.tsx
+++ b/src/components/domain/SignupForm/Fields/NicknameField.tsx
@@ -36,10 +36,10 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
   const handleClickDuplicate = async () => {
     try {
       await UserApi.nicknameCheck({ nickname: value });
-      window.alert(`${value}는 사용가능한 닉네임입니다!`);
+      window.alert(`${value}는 사용가능한 닉네임입니다.`);
       checkDuplicate && checkDuplicate(true);
     } catch (e) {
-      window.alert('이미 존재하는 닉네임이에요!');
+      window.alert('이미 존재하는 닉네임입니다.');
     }
   };
 

--- a/src/components/domain/SignupForm/Fields/NicknameField.tsx
+++ b/src/components/domain/SignupForm/Fields/NicknameField.tsx
@@ -8,7 +8,7 @@ interface NicknameFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   errors: string | undefined;
-  checkDuplicate: React.Dispatch<React.SetStateAction<boolean>>;
+  checkDuplicate?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const NicknameField: React.FC<NicknameFieldProps> = ({
@@ -25,7 +25,7 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      checkDuplicate(false);
+      checkDuplicate && checkDuplicate(false);
       onChange(e);
     },
     [onChange, checkDuplicate]
@@ -34,13 +34,10 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
   const disabled = useMemo(() => !!error || value.length === 0, [error, value]);
 
   const handleClickDuplicate = async () => {
-    if (disabled) {
-      return;
-    }
     try {
       await UserApi.nicknameCheck({ nickname: value });
       window.alert(`${value}는 사용가능한 닉네임입니다!`);
-      checkDuplicate(true);
+      checkDuplicate && checkDuplicate(true);
     } catch (e) {
       window.alert('이미 존재하는 닉네임이에요!');
     }
@@ -50,7 +47,7 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
     <Field>
       <Label htmlFor="nickname" text="닉네임" />
       <Text size="xs" color="gray">
-        특수문자가 포함되지 않는 2~8자리로 설정해주세요.
+        특수문자를 제외한 2~8자리로 설정해주세요.
       </Text>
       <StyledField>
         <Input

--- a/src/components/domain/SignupForm/Fields/PasswordCheckField.tsx
+++ b/src/components/domain/SignupForm/Fields/PasswordCheckField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useState } from 'react';
+import React, { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { Input, Label } from '~/components/atom';
 import { ErrorMessage, Field } from '~/components/common';
 
@@ -6,14 +6,26 @@ interface PasswordCheckFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   errors: string | undefined;
+  password: string;
 }
 
-const PasswordCheckField: React.FC<PasswordCheckFieldProps> = ({ value, onChange, errors }) => {
+const PasswordCheckField: React.FC<PasswordCheckFieldProps> = ({
+  value,
+  onChange,
+  errors,
+  password
+}) => {
   const [error, setError] = useState(errors);
 
   const handleBlur = useCallback(() => {
     setError(errors);
   }, [errors]);
+
+  useEffect(() => {
+    if (value && password !== value) {
+      setError(errors);
+    }
+  }, [password, errors, value]);
 
   return (
     <Field>

--- a/src/components/domain/SignupForm/index.tsx
+++ b/src/components/domain/SignupForm/index.tsx
@@ -31,35 +31,24 @@ const initialValues: SignupValues = {
 const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction }) => {
   const [isCheckedDuplicateEmail, setIsCheckedDuplicateEmail] = useState(false);
   const [isCheckedDuplicateNickname, setIsCheckedDuplicateNickname] = useState(false);
-  const initDuplicatedEmail = useCallback(() => setIsCheckedDuplicateEmail(false), []);
-  const initDuplicatedNickname = useCallback(() => setIsCheckedDuplicateNickname(false), []);
-  const checkDuplicatedEmail = () => setIsCheckedDuplicateEmail(true);
-  const checkDuplicatedNickname = () => setIsCheckedDuplicateNickname(true);
 
-  const { values, handleChange, handleSubmit, errors } = useFormik({
+  const { values, handleChange, handleSubmit, errors, setErrors } = useFormik({
     initialValues,
     validationSchema: SignupValidationRules,
     onSubmit: (data: SignupValues) => {
-      if (!isCheckedDuplicateEmail) {
-        //TODO - ConfirmModal 사용하기
-        window.alert('이메일 중복확인을 해주세요.');
-        return;
-      }
-      if (!isCheckedDuplicateNickname) {
-        //TODO - ConfirmModal 사용하기
-        window.alert('닉네임 중복확인을 해주세요.');
-        return;
-      }
       handleSubmitAction && handleSubmitAction(data);
     }
   });
 
   const disabled = useMemo(() => {
+    if (!isCheckedDuplicateEmail || !isCheckedDuplicateNickname) {
+      return true;
+    }
     return (
       Object.values(values).some((value) => value.length === 0) ||
       Object.entries(errors).some((error) => !!error)
     );
-  }, [values, errors]);
+  }, [values, errors, isCheckedDuplicateEmail, isCheckedDuplicateNickname]);
 
   return (
     <Layout>
@@ -73,8 +62,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               value={values.email}
               onChange={handleChange}
               errors={errors.email}
-              setInitDuplicateFn={initDuplicatedEmail}
-              setDuplicateCheckFn={checkDuplicatedEmail}
+              checkDuplicate={setIsCheckedDuplicateEmail}
             />
             <PasswordField
               value={values.password}
@@ -90,8 +78,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               value={values.nickname}
               onChange={handleChange}
               errors={errors.nickname}
-              setInitDuplicateFn={initDuplicatedNickname}
-              setDuplicateCheckFn={checkDuplicatedNickname}
+              checkDuplicate={setIsCheckedDuplicateNickname}
             />
             <BirthField value={values.birth} onChange={handleChange} errors={errors.birth} />
             <SexField value={values.sex} onChange={handleChange} />

--- a/src/components/domain/SignupForm/index.tsx
+++ b/src/components/domain/SignupForm/index.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import { useFormik } from 'formik';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Button, PageContainer, Title } from '~/components/atom';
-import { Form } from '~/components/common';
+import { ErrorMessage, Form } from '~/components/common';
 import theme from '~/styles/theme';
 import { SignupValues } from '~/types';
 import {
@@ -29,26 +29,28 @@ const initialValues: SignupValues = {
 };
 
 const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction }) => {
+  const [errorMessage, setErrorMessage] = useState(false);
   const [isCheckedDuplicateEmail, setIsCheckedDuplicateEmail] = useState(false);
   const [isCheckedDuplicateNickname, setIsCheckedDuplicateNickname] = useState(false);
 
-  const { values, handleChange, handleSubmit, errors, setErrors } = useFormik({
+  const { values, handleChange, handleSubmit, errors } = useFormik<SignupValues>({
     initialValues,
     validationSchema: SignupValidationRules,
     onSubmit: (data: SignupValues) => {
+      if (!isCheckedDuplicateEmail || !isCheckedDuplicateNickname) {
+        setErrorMessage(true);
+        return;
+      }
       handleSubmitAction && handleSubmitAction(data);
     }
   });
 
   const disabled = useMemo(() => {
-    if (!isCheckedDuplicateEmail || !isCheckedDuplicateNickname) {
-      return true;
-    }
     return (
       Object.values(values).some((value) => value.length === 0) ||
       Object.entries(errors).some((error) => !!error)
     );
-  }, [values, errors, isCheckedDuplicateEmail, isCheckedDuplicateNickname]);
+  }, [values, errors]);
 
   return (
     <Layout>
@@ -64,6 +66,11 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               errors={errors.email}
               checkDuplicate={setIsCheckedDuplicateEmail}
             />
+            {errorMessage && !isCheckedDuplicateEmail && (
+              <DuplicatedError>
+                <ErrorMessage message="이메일 중복 검사를 해주세요." />
+              </DuplicatedError>
+            )}
             <PasswordField
               value={values.password}
               onChange={handleChange}
@@ -73,6 +80,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               value={values.passwordCheck}
               onChange={handleChange}
               errors={errors.passwordCheck}
+              password={values.password}
             />
             <NicknameField
               value={values.nickname}
@@ -80,6 +88,11 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               errors={errors.nickname}
               checkDuplicate={setIsCheckedDuplicateNickname}
             />
+            {errorMessage && !isCheckedDuplicateNickname && (
+              <DuplicatedError>
+                <ErrorMessage message="닉네임 중복 검사를 해주세요." />
+              </DuplicatedError>
+            )}
             <BirthField value={values.birth} onChange={handleChange} errors={errors.birth} />
             <SexField value={values.sex} onChange={handleChange} />
           </Fields>
@@ -111,4 +124,8 @@ const Fields = styled.div`
   display: flex;
   flex-direction: column;
   gap: 30px;
+`;
+
+const DuplicatedError = styled.div`
+  margin-top: -20px;
 `;

--- a/src/components/domain/SignupForm/rules.ts
+++ b/src/components/domain/SignupForm/rules.ts
@@ -43,6 +43,7 @@ export const SignupValidationRules: ObjectSchema<Assign<ObjectShape, SchemaInter
     nickname: string()
       .min(2, MESSAGE.nickname)
       .max(8, MESSAGE.nickname)
+      .matches(VALIDATION.nickname, MESSAGE.nickname)
       .required('닉네임을 입력해주세요.'),
     birth: string().matches(VALIDATION.birth, MESSAGE.birth).required('생년월일을 입력해주세요.'),
     sex: mixed().oneOf(['male', 'female']).required('성별을 선택해주세요.')

--- a/src/components/domain/SignupForm/rules.ts
+++ b/src/components/domain/SignupForm/rules.ts
@@ -7,7 +7,7 @@ import { AnyObject } from 'yup/lib/types';
 const MESSAGE = {
   password: '비밀번호는 영문, 숫자, 특수문자를 포함한 8~15자로 설정해주세요.',
   passwordCheck: '동일한 비밀번호가 아니에요.',
-  nickname: '닉네임은 특수문자가 포함되지 않는 2~8자리로 설정해주세요.',
+  nickname: '닉네임은 특수문자를 제외한 2~8자리로 설정해주세요.',
   birth: '올바른 생년월일을 입력해주세요.'
 };
 

--- a/src/components/domain/UserInfo/EditForm/index.tsx
+++ b/src/components/domain/UserInfo/EditForm/index.tsx
@@ -52,13 +52,13 @@ const UserEditForm = ({ initialValues, onSubmit: onSubmitAction }: UserEditForm)
     try {
       const response = await UserApi.nicknameCheck({ nickname: values.nickname });
       if (response.status === 200) {
-        window.alert(`${values.nickname}는 사용가능한 닉네임입니다!`);
+        window.alert(`${values.nickname}는 사용가능한 닉네임입니다.`);
         setIsCheckedDuplicateNickname(true);
         setNicknameError('');
         return;
       }
     } catch (e) {
-      setNicknameError('이미 존재하는 닉네임이에요.');
+      setNicknameError('이미 존재하는 닉네임입니다.');
     }
   };
 

--- a/src/components/domain/UserInfo/EditForm/rules.ts
+++ b/src/components/domain/UserInfo/EditForm/rules.ts
@@ -5,7 +5,7 @@ import { RequiredStringSchema } from 'yup/lib/string';
 import { AnyObject } from 'yup/lib/types';
 
 const MESSAGE = {
-  nickname: '닉네임은 특수문자가 포함되지 않는 2~8자리로 설정해주세요.',
+  nickname: '닉네임은 특수문자를 제외한 2~8자리로 설정해주세요.',
   birth: '올바른 생년월일을 입력해주세요.'
 };
 

--- a/src/components/domain/UserInfo/EditForm/rules.ts
+++ b/src/components/domain/UserInfo/EditForm/rules.ts
@@ -24,6 +24,7 @@ export const ValidationRules: ObjectSchema<Assign<ObjectShape, SchemaInterface>>
   nickname: string()
     .min(2, MESSAGE.nickname)
     .max(8, MESSAGE.nickname)
+    .matches(VALIDATION.nickname, MESSAGE.nickname)
     .required('닉네임을 입력해주세요.'),
   birth: string().matches(VALIDATION.birth, MESSAGE.birth).required('생년월일을 입력해주세요.'),
   sex: mixed().oneOf(['male', 'female']).required('성별을 선택해주세요.')

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -10,13 +10,15 @@ const Signup: NextPage = () => {
   const router = useRouter();
 
   const handleSubmit = async (data: SignupValues) => {
-    // TODO
-    // 회원가입 실패 시 로직 추가해야함
-    const response = await UserApi.signup(data);
-    if (response.nickname === data.nickname) {
-      if (window.confirm(`${response.nickname}님 환영합니다! 로그인하러 갈까요?`)) {
-        router.push('/login');
+    try {
+      const response = await UserApi.signup(data);
+      if (response.nickname === data.nickname) {
+        if (window.confirm(`${response.nickname}님 환영합니다! 로그인하러 갈까요?`)) {
+          router.push('/login');
+        }
       }
+    } catch (e) {
+      console.error('회원가입 실패', e);
     }
   };
 

--- a/src/pages/userinfo/[id]/edit.tsx
+++ b/src/pages/userinfo/[id]/edit.tsx
@@ -33,7 +33,7 @@ const UserinfoEdit: NextPage = () => {
       }
     } catch (e) {
       // TODO 이후 status code에 따른 예외처리
-      console.error(e);
+      console.error('회원정보 수정 실패', e);
     }
   };
 

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -36,7 +36,7 @@ const UserinfoEdit: NextPage = () => {
         window.alert('동일한 비밀번호로는 변경할 수 없어요.');
         return;
       }
-      console.error(e);
+      console.error('비밀번호 수정 실패', e);
     }
   };
 


### PR DESCRIPTION
# ✅ 이슈번호
closes #45 

# 📌 구현 내역
## 설명

1. UX개선) 사용자에게 이메일, 닉네임 중복검사를 하라는 메시지를 `window.alert`에서 `ErrorMessage`로 개선하였습니다.
2. UX개선) 비밀번호를 입력하고 -> 비밀번호 확인을 입력하고 -> 다시 비밀번호를 변경하였을 때, 비밀번호 확인에 에러메시지가 나타나도록 하였습니다.
3. UX추가) "비밀번호 확인"은 유저가 피드백을 빠르게 받는 것이 좋을 것 같아 `blur` 후 에러메시지를 보이지 않고 바로 에러메시지를 만나도록 하였습니다. 
4. validation 개선) 닉네임에 공백 등 특수문자를 사용하지 못하도록 하는 validation을 추가하였습니다.

## 이미지

![form2](https://user-images.githubusercontent.com/64957267/183934393-5dab319f-123c-49fb-ae45-891c463a2985.gif)
