### PR TITLE
fix: 로그인 실패시 에러처리

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -10,9 +10,10 @@ import SearchInput from '../SearchInput';
 
 interface HeaderProps {
   full?: boolean;
+  isLoading?: boolean;
 }
 
-const Header = ({ full }: HeaderProps) => {
+const Header = ({ full, isLoading }: HeaderProps) => {
   const { currentUser, isLoggedIn } = useUser();
 
   const router = useRouter();
@@ -68,12 +69,12 @@ const Header = ({ full }: HeaderProps) => {
               <Link href="/course/create">
                 <Button>코스등록</Button>
               </Link>
-              {!isLoggedIn && !currentUser.isLoading && (
+              {!isLoggedIn && !isLoading && (
                 <Link href="/login">
                   <Button buttonType="borderPrimary">로그인</Button>
                 </Link>
               )}
-              {isLoggedIn && !currentUser.isLoading && (
+              {isLoggedIn && !isLoading && (
                 <Link href={`/userinfo/${currentUser.user.id}`}>
                   <Avatar size={54} src={currentUser.user.profileImage} />
                 </Link>

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { Header } from '~/components/common';
 import Footer from '~/components/common/Footer';
 import { useUser } from '~/hooks/useUser';
@@ -12,17 +12,23 @@ interface LayoutProps {
 
 const Layout = ({ children, footer, full }: LayoutProps) => {
   const { currentUser, updateUser } = useUser();
+  const [isLoading, setIsLoading] = useState(false);
 
+  const compareUser = async (token: string) => {
+    setIsLoading(true);
+    await updateUser(token);
+    setIsLoading(false);
+  };
   useEffect(() => {
     const token = WebStorage.getToken();
     if (token && currentUser.accessToken !== token) {
-      updateUser(token);
+      compareUser(token);
     }
   }, [currentUser.accessToken]);
 
   return (
     <div>
-      <Header full={full} />
+      <Header full={full} isLoading={isLoading} />
       {children}
       {footer && <Footer />}
     </div>

--- a/src/components/domain/LoginForm/index.tsx
+++ b/src/components/domain/LoginForm/index.tsx
@@ -20,9 +20,10 @@ const initialValues: LoginValues = {
 
 interface LoginFormProps {
   onSubmit: (data: LoginValues) => void;
+  errorMessage: string;
 }
 
-const LoginForm: React.FC<LoginFormProps> = ({ onSubmit: handleSubmitAction }) => {
+const LoginForm = ({ onSubmit: handleSubmitAction, errorMessage }: LoginFormProps) => {
   const { values, handleChange, handleSubmit } = useFormik({
     initialValues,
     onSubmit: (data: LoginValues) => {
@@ -59,6 +60,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSubmit: handleSubmitAction }) =
               value={values.password}
               onChange={handleChange}
             />
+            <Text color="red">{errorMessage}</Text>
             <Button type="submit" disabled={submittable}>
               로그인
             </Button>

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,5 +1,4 @@
 import { ErrorConfirm } from './../types/user';
-import { useState } from 'react';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 import { userState } from '~/recoil';
 import { UserApi } from '~/service';

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,19 +1,55 @@
+import { ErrorConfirm } from './../types/user';
+import { useState } from 'react';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 import { userState } from '~/recoil';
 import { UserApi } from '~/service';
 import WebStorage from '~/service/core/WebStorage';
 import { LoginValues } from '~/types';
 
+interface SystemError {
+  code: string;
+  message: string;
+  response: {
+    status: number;
+  };
+}
+
 export const useUser = () => {
   const [currentUser, setCurrentUser] = useRecoilState(userState);
   const resetUser = useResetRecoilState(userState);
   const isLoggedIn = currentUser.accessToken !== null;
 
-  const login = async (data: LoginValues) => {
+  const login = async (data: LoginValues): Promise<ErrorConfirm> => {
     setCurrentUser({ ...currentUser, isLoading: true });
-    const response = await UserApi.login(data);
-    setCurrentUser({ ...response, isLoading: false });
-    WebStorage.setToken(response.accessToken);
+
+    try {
+      const response = await UserApi.login(data);
+      setCurrentUser({ ...response, isLoading: false });
+      WebStorage.setToken(response.accessToken);
+
+      return {
+        isError: false,
+        message: ''
+      };
+    } catch (error) {
+      const e = error as SystemError;
+      setCurrentUser({ ...currentUser, isLoading: false });
+
+      let message = '';
+
+      if (e.response.status === 401) {
+        message = '비밀번호가 일치하지 않습니다.';
+      }
+
+      if (e.response.status === 404) {
+        message = '아이디 비밀번호를 다시 입력해주세요.';
+      }
+
+      return {
+        isError: true,
+        message
+      };
+    }
   };
 
   const updateUser = async (token: string) => {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -19,11 +19,11 @@ export const useUser = () => {
   const isLoggedIn = currentUser.accessToken !== null;
 
   const login = async (data: LoginValues): Promise<ErrorConfirm> => {
-    setCurrentUser({ ...currentUser, isLoading: true });
+    setCurrentUser({ ...currentUser });
 
     try {
       const response = await UserApi.login(data);
-      setCurrentUser({ ...response, isLoading: false });
+      setCurrentUser({ ...response });
       WebStorage.setToken(response.accessToken);
 
       return {
@@ -32,7 +32,7 @@ export const useUser = () => {
       };
     } catch (error) {
       const e = error as SystemError;
-      setCurrentUser({ ...currentUser, isLoading: false });
+      setCurrentUser({ ...currentUser });
 
       let message = '';
 
@@ -52,7 +52,7 @@ export const useUser = () => {
   };
 
   const updateUser = async (token: string) => {
-    setCurrentUser({ ...currentUser, isLoading: true });
+    setCurrentUser({ ...currentUser });
 
     const response = await UserApi.getMyInfo();
     console.log(response, '★update User★');
@@ -62,8 +62,7 @@ export const useUser = () => {
         id: response.id,
         nickname: response.nickname,
         profileImage: response.profileImage
-      },
-      isLoading: false
+      }
     });
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,6 @@ import Layout from '~/components/common/Layout';
 import ArrowTitle from '~/components/common/ArrowTitle';
 import { CourseApi, PlaceApi } from '~/service';
 import theme from '~/styles/theme';
-import { Theme } from '~/types';
 import { TAGS_THEME } from '~/utils/constants';
 
 const HomePage = () => {
@@ -20,14 +19,12 @@ const HomePage = () => {
   const PLACE_COUNT = 4;
 
   const getCourseList = async () => {
-    const filter = { size: COURSE_COUNT };
-    const result = await CourseApi.getCourses(filter);
-    console.log('[Courses] :', result.content);
+    const result = await CourseApi.getCourses({ size: COURSE_COUNT, sorting: '인기순' });
     setCourseList(result.content);
   };
 
   const getPlaceList = async () => {
-    const result = await PlaceApi.getPlaces({ size: PLACE_COUNT });
+    const result = await PlaceApi.getPlaces({ size: PLACE_COUNT, sorting: '인기순' });
     setPlaceList(result.content);
   };
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import React from 'react';
+import React, { useState } from 'react';
 import { LoginForm } from '~/components/domain';
 import { LoginValues } from '~/types';
 import { useUser } from '~/hooks/useUser';
@@ -9,10 +9,15 @@ import { useRouter } from 'next/router';
 const Login: NextPage = () => {
   const { login } = useUser();
   const router = useRouter();
+  const [errorMessage, setErrorMessage] = useState('');
 
   const handleSubmit = async (data: LoginValues) => {
-    login(data);
-    router.push('/');
+    const result = await login(data);
+    if (!result.isError) {
+      router.push('/');
+    } else {
+      setErrorMessage(result.message);
+    }
   };
 
   return (
@@ -24,7 +29,7 @@ const Login: NextPage = () => {
       </Head>
 
       <main>
-        <LoginForm onSubmit={handleSubmit} />
+        <LoginForm onSubmit={handleSubmit} errorMessage={errorMessage} />
       </main>
     </React.Fragment>
   );

--- a/src/pages/userinfo/[id]/edit.tsx
+++ b/src/pages/userinfo/[id]/edit.tsx
@@ -50,7 +50,7 @@ const UserinfoEdit: NextPage = () => {
 
   useEffect(() => {
     if (typeof router.query.id === 'string') {
-      if (!currentUser.isLoading && currentUser.user.id !== userId) {
+      if (currentUser.user.id !== userId) {
         alert('잘못된 요청입니다.');
         router.push('/');
         return;

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -42,7 +42,7 @@ const UserinfoEdit: NextPage = () => {
 
   useEffect(() => {
     if (typeof router.query.id === 'string') {
-      if (!currentUser.isLoading && currentUser.user.id !== userId) {
+      if (currentUser.user.id !== userId) {
         alert('잘못된 요청입니다.');
         router.push('/');
         return;

--- a/src/recoil/index.ts
+++ b/src/recoil/index.ts
@@ -10,7 +10,6 @@ export const userState = atom<UserState>({
       id: null,
       nickname: null,
       profileImage: null
-    },
-    isLoading: false
+    }
   }
 });

--- a/src/service/domains/user.ts
+++ b/src/service/domains/user.ts
@@ -16,21 +16,13 @@ class UserApi extends Api {
   private path = '/users';
 
   login = async (bodyData: LoginValues) => {
-    try {
-      const response = await this.baseInstance.post(`${this.path}/login`, bodyData);
-      return response.data;
-    } catch (e) {
-      console.error(`로그인 에러: `, e);
-    }
+    const response = await this.baseInstance.post(`${this.path}/login`, bodyData);
+    return response.data;
   };
 
   signup = async (bodyData: SignupValues) => {
-    try {
-      const response = await this.baseInstance.post(`${this.path}/`, bodyData);
-      return response.data;
-    } catch (e) {
-      console.error(`회원가입 에러:`, e);
-    }
+    const response = await this.baseInstance.post(`${this.path}/`, bodyData);
+    return response.data;
   };
 
   emailCheck = async (bodyData: { email: string }) => {

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -27,5 +27,5 @@ export interface PlaceFilter {
   keyword?: string;
   page?: number;
   size?: number;
-  sort?: SortType;
+  sorting?: SortType;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -7,7 +7,6 @@ export interface User {
 export interface UserState {
   accessToken: string | null;
   user: User;
-  isLoading: boolean;
 }
 
 export interface UserInfo {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -32,3 +32,8 @@ export interface UserPasswordFormValues {
   password: string;
   passwordCheck: string;
 }
+
+export interface ErrorConfirm {
+  isError: boolean;
+  message: string;
+}


### PR DESCRIPTION
# ✅ 이슈번호
closes #154 


# 📌 구현 내역
## 로그인 실패시 에러 수정
- 로그인 실패 시 에러와 함께 페이지가 표시되지 않는 에러를 수정했습니다.
- 로그인 실패 시 에러 메세지를 하단에 표시하도록 변경하였습니다.
- 이 과정에서 로그인 시도 시 상단 헤더의 버튼이 깜빡이는 현상이 발생하여 전역으로 관리하던 isLoading값을 제거하고
따로 layout(header)에서 관리하도록 수정하였습니다.

- 추가로 메인페이지 코스, 장소 인기순으로 보여지도록 변경했습니다.

![login](https://user-images.githubusercontent.com/81489300/184368827-7581b836-c964-4edd-a925-d32553cea0a6.gif)

