### PR TITLE
fix: 코스 상세페이지 수정

### DIFF
--- a/public/assets/icons/arrow-left.svg
+++ b/public/assets/icons/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.5 7L10.5 14L17.5 21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/icons/arrow-right.svg
+++ b/public/assets/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5 21L17.5 14L10.5 7" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/atom/Icon/types.ts
+++ b/src/components/atom/Icon/types.ts
@@ -1,6 +1,8 @@
 export const ICON_URLS = {
   heart: '/assets/icons/heart.svg',
   arrow: '/assets/icons/arrow.svg',
+  arrowLeft: '/assets/icons/arrow-left.svg',
+  arrowRight: '/assets/icons/arrow-right.svg',
   arrowDown: '/assets/icons/arrow-down.svg',
   calendar: '/assets/icons/calendar.svg',
   marker: '/assets/icons/marker.svg',

--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useCallback, useState } from 'react';
 import { Button, Link, Text } from '~/components/atom';
 import Avatar from '~/components/atom/Avatar';
+import { useUser } from '~/hooks/useUser';
 import theme from '~/styles/theme';
 import { IComment } from '~/types/comment';
 import { sliceDate } from '~/utils/converter';
@@ -31,6 +32,7 @@ const CommentItem = ({
   const [isOpenEditor, setIsOpenEditor] = useState(false);
   const [isOpenRecomment, setIsOpenRecomment] = useState(false);
   const isRecomment = comment.rootCommentId !== null;
+  const { currentUser } = useUser();
 
   const IS_UPDATED = comment.createdAt !== comment.updatedAt;
 
@@ -92,14 +94,16 @@ const CommentItem = ({
                 )}
               </CommentInfo>
             </CommentContent>
-            <Buttons>
-              <Text.Button color="gray" onClick={() => setIsOpenEditor(true)}>
-                수정
-              </Text.Button>
-              <Text.Button color="gray" onClick={handleDelete}>
-                삭제
-              </Text.Button>
-            </Buttons>
+            {currentUser.user.id === comment.user.id && (
+              <Buttons>
+                <Text.Button color="gray" onClick={() => setIsOpenEditor(true)}>
+                  수정
+                </Text.Button>
+                <Text.Button color="gray" onClick={handleDelete}>
+                  삭제
+                </Text.Button>
+              </Buttons>
+            )}
           </>
         ) : (
           <CommentEditor

--- a/src/components/domain/CourseSlider/CourseSliderItem.tsx
+++ b/src/components/domain/CourseSlider/CourseSliderItem.tsx
@@ -4,7 +4,7 @@ import theme from '~/styles/theme';
 
 interface CourseSliderItemProps {
   name: string;
-  id: number;
+  placeId: number;
   index: number;
   lastCount: number;
   imageUrl: string;
@@ -13,7 +13,7 @@ interface CourseSliderItemProps {
 const DOT_BG = 'url(/assets/dot-gray.png)';
 const LINE_BG = 'url(/assets/line-bluegray.png)';
 
-const CourseSliderItem = ({ name, id, index, lastCount, imageUrl }: CourseSliderItemProps) => {
+const CourseSliderItem = ({ name, placeId, index, lastCount, imageUrl }: CourseSliderItemProps) => {
   const IS_START = index === 0;
   const IS_END = index === lastCount - 1;
 
@@ -40,7 +40,7 @@ const CourseSliderItem = ({ name, id, index, lastCount, imageUrl }: CourseSlider
               {name}
             </Title>
           </TitleContainer>
-          <Link href={`/place/${id}`}>
+          <Link href={`/place/${placeId}`}>
             <Button buttonType="borderPrimary">장소정보보기</Button>
           </Link>
         </CardInfo>

--- a/src/components/domain/CourseSlider/CourseSliderItem.tsx
+++ b/src/components/domain/CourseSlider/CourseSliderItem.tsx
@@ -36,7 +36,9 @@ const CourseSliderItem = ({ name, id, index, lastCount, imageUrl }: CourseSlider
         <CardImage style={{ backgroundImage: `url(${IMAGE_URL})` }}></CardImage>
         <CardInfo>
           <TitleContainer>
-            <Title ellipsis>{name}</Title>
+            <Title size={22} ellipsis>
+              {name}
+            </Title>
           </TitleContainer>
           <Link href={`/place/${id}`}>
             <Button buttonType="borderPrimary">장소정보보기</Button>
@@ -92,9 +94,10 @@ const CourseCard = styled.div`
 
 const CardImage = styled.div`
   border-radius: 8px 8px 0 0;
-  height: 230px;
+  height: 210px;
   background-size: cover;
   background-color: ${backgroundGray};
+  background-position: center;
 `;
 
 const CardInfo = styled.div`

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -38,6 +38,7 @@ const CourseSlider = ({ places }: CourseSliderProps) => {
 export default CourseSlider;
 
 const { borderDarkGray } = theme.color;
+const { basicShadow } = theme.shadow;
 
 export const StyledSlider = styled(Slider)`
   margin-top: 24px;
@@ -52,15 +53,28 @@ export const StyledSlider = styled(Slider)`
     background-color: white;
     border-radius: 50%;
     border: 1px solid ${borderDarkGray};
-    width: 55px;
-    height: 55px;
+    width: 50px;
+    height: 50px;
     z-index: 100;
-    background-image: url('/assets/icons/arrow.svg');
     background-repeat: no-repeat;
     background-position: center;
+    box-shadow: ${basicShadow};
+    transition: all 0.1s;
+
+    &:hover {
+      background-color: #f7f8f9;
+    }
+
+    &.slick-disabled {
+      display: none !important;
+    }
+  }
+
+  .slick-next {
+    background-image: url('/assets/icons/arrow-right.svg');
   }
   .slick-prev {
-    transform: translate(0, -50%) rotate(180deg);
+    background-image: url('/assets/icons/arrow-left.svg');
   }
 
   .slick-next:before,

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -25,7 +25,7 @@ const CourseSlider = ({ places }: CourseSliderProps) => {
         <CourseSliderItem
           key={place.id}
           name={place.name}
-          id={place.id}
+          placeId={place.placeId}
           index={index}
           lastCount={places.length}
           imageUrl={place.imageUrl}

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -30,6 +30,7 @@ const CourseDetail: NextPage = () => {
   const getDetailInfo = async (courseId: number) => {
     if (isLoggedIn) {
       const result = await CourseApi.authRead(courseId);
+      console.log('로그인 데이터', result);
 
       if (!result) {
         // 임시로 값 없을 경우 처리

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -105,7 +105,7 @@ const CourseDetail: NextPage = () => {
 
             <Profile>
               <Link href={`/userinfo/${detailData.userId}`}>
-                <Avatar size={66} />
+                <Avatar size={55} src={detailData.profileImage} />
               </Link>
               <Text color="dark" fontWeight={500}>
                 {detailData.nickname}

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -12,6 +12,7 @@ export interface IPlaceItem {
 
 export interface IPlace {
   id: number;
+  placeId: number;
   name: string;
   description: string;
   address: string;


### PR DESCRIPTION
# ✅ 이슈번호
closes #157 

# 📌 구현 내역

## 코스 상세페이지 수정
- [X]  댓글 작성자만 수정/삭제 가능하도록 처리했습니다.
- [X] placeId API 필드 추가되어 연결했습니다
 : 이제 장소 상세보기 누르면 상세페이지로 연결됩니다
- [X] 다녀온 코스 슬라이더 이전/다음 페이지 없을경우 prev/next 버튼 안보이도록 수정했습니다.
- [X] 다녀온 코스 부분 페이지 width변경으로 찌그러진 레이아웃 수정하고 이미지도 가운데로 맞췄습니다.
- [X] 유저 프로필 나오도록 api로 받은 데이터 연결했습니다.
