### PR TITLE
feat: 카카오톡 공유하기 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+
+.vscode

--- a/src/components/common/DetailSidebar/index.tsx
+++ b/src/components/common/DetailSidebar/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { Icon, Text } from '~/components/atom';
+import KakaoButton from '~/components/domain/CourseDetail/KakaoButton';
 import { useUser } from '~/hooks/useUser';
 import { BookmarkApi, LikeApi } from '~/service';
 import theme from '~/styles/theme';
@@ -75,10 +76,7 @@ const DetailSidebar = ({
             <Icon name="bookmarkInactive" size={28} />
           )}
         </IconButton>
-
-        <IconButton>
-          <Icon name="share" size={28} />
-        </IconButton>
+        <KakaoButton />
       </Sticky>
     </Container>
   );

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -20,6 +20,13 @@ const Layout = ({ children, footer, full }: LayoutProps) => {
     }
   }, [currentUser.accessToken]);
 
+  useEffect(() => {
+    const kakao = window.Kakao;
+    if (!kakao.isInitialized()) {
+      kakao.init(process.env.NEXT_PUBLIC_KAKAO_SHARE_KEY);
+    }
+  }, []);
+
   return (
     <div>
       <Header full={full} />

--- a/src/components/domain/CourseDetail/KakaoButton/index.tsx
+++ b/src/components/domain/CourseDetail/KakaoButton/index.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+import { Icon } from '~/components/atom';
+import theme from '~/styles/theme';
+
+const KakaoButton = () => {
+  const onClick = () => {
+    const { Kakao, location } = window;
+    Kakao.Share.sendScrap({
+      templateId: 81335,
+      requestUrl: location.href
+    });
+  };
+  return (
+    <IconButton id="kakao-link-btn" onClick={onClick}>
+      <Icon name="share" size={28} />
+    </IconButton>
+  );
+};
+
+export default KakaoButton;
+
+const { borderDarkGray } = theme.color;
+const IconButton = styled.button`
+  width: 66px;
+  height: 66px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  border-radius: 50%;
+  border: 1px solid ${borderDarkGray};
+  margin-top: 20px;
+  box-shadow: 0px 2px 4px 1px rgb(0 0 0 / 5%);
+  transition: all 0.3s;
+
+  &:hover {
+    border-color: #adadad;
+  }
+`;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,12 @@ import { RecoilRoot } from 'recoil';
 export type NextPageWithLayout = NextPage & { getLayout?: (page: ReactElement) => ReactNode };
 type AppPropsWidthLayout = AppProps & { Component: NextPageWithLayout };
 
+declare global {
+  interface Window {
+    Kakao: any;
+  }
+}
+
 function MyApp({ Component, pageProps }: AppPropsWidthLayout) {
   const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>);
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,6 +10,7 @@ class MainDocument extends Document {
     return (
       <Html>
         <Head />
+        <script defer src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
# ✅ 이슈번호
closes #161 

# 📌 구현 내역

## 카카오톡 공유하기 기능
- 코스,장소 상세페이지에 공유하기 버튼에 카카오 카카오 API를 사용했습니다.
- 공유하기링크로 들어올 경우 해당 페이지가 아닌 홈으로 접근이 되는데 이부분은 다시 알아보고 적용을 해보겠습니다.
![공유하기](https://user-images.githubusercontent.com/81489300/184428430-9ade863f-8764-48b1-bc88-238c52ddb0ad.gif)

