### PR TITLE
feat: Toast 컴포넌트 구현 및 적용, Form 메세지 UX 리팩터링, 생년월일 필드 리팩터링, 캡스락 경고 추가

### DIFF
--- a/src/components/atom/Modal/BackgroundDim.tsx
+++ b/src/components/atom/Modal/BackgroundDim.tsx
@@ -1,14 +1,9 @@
 import styled from '@emotion/styled';
-import React, { ReactNode, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useClickAway } from '~/hooks';
+import { ModalProps } from '.';
 
-export interface BackgroundDimProps {
-  visible: boolean;
-  children: ReactNode;
-  onClose?: () => void;
-  closeDimActive?: boolean;
-  dimOpacity?: number;
-}
+type BackgroundDimProps = ModalProps;
 
 const blockTabKey = (e: KeyboardEvent): void => {
   if (e.key === 'Tab') {
@@ -21,7 +16,7 @@ const BackgroundDim = ({
   children,
   onClose,
   closeDimActive = true,
-  dimOpacity = 0.5
+  dimOpacity = 0.2
 }: BackgroundDimProps) => {
   const ref = useClickAway<HTMLDivElement>(() => {
     if (closeDimActive && onClose) {
@@ -30,15 +25,17 @@ const BackgroundDim = ({
   });
 
   useEffect(() => {
-    document.body.classList.add('modal-open');
-    document.addEventListener('keydown', blockTabKey);
-    document.addEventListener('keyup', blockTabKey);
+    if (visible) {
+      document.body.classList.add('modal-open');
+      document.addEventListener('keydown', blockTabKey);
+      document.addEventListener('keyup', blockTabKey);
+    }
     return () => {
       document.body.classList.remove('modal-open');
       document.removeEventListener('keydown', blockTabKey);
       document.removeEventListener('keyup', blockTabKey);
     };
-  }, []);
+  }, [visible]);
   return (
     <Background visible={visible} dimOpacity={dimOpacity}>
       <Inner ref={ref}>{children}</Inner>

--- a/src/components/atom/Modal/BackgroundDim.tsx
+++ b/src/components/atom/Modal/BackgroundDim.tsx
@@ -16,7 +16,7 @@ const BackgroundDim = ({
   children,
   onClose,
   closeDimActive = true,
-  dimOpacity = 0.2
+  dimOpacity = 0.1
 }: BackgroundDimProps) => {
   const ref = useClickAway<HTMLDivElement>(() => {
     if (closeDimActive && onClose) {

--- a/src/components/atom/Modal/index.tsx
+++ b/src/components/atom/Modal/index.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import Portal from './Portal';
-import BackgroundDim, { BackgroundDimProps } from './BackgroundDim';
+import BackgroundDim from './BackgroundDim';
 import styled from '@emotion/styled';
 
-type ModalProps = BackgroundDimProps;
+export interface ModalProps {
+  visible: boolean;
+  children: ReactNode;
+  onClose?: () => void;
+  closeDimActive?: boolean;
+  dimOpacity?: number;
+}
 
 const Modal = ({ ...props }: ModalProps) => {
   return (

--- a/src/components/common/Form/FieldMessage.tsx
+++ b/src/components/common/Form/FieldMessage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text } from '~/components/atom';
+import { TextProps } from '~/components/atom/Text';
+
+interface FieldMessageProps extends Pick<TextProps, 'color'> {
+  message: string;
+}
+
+const FieldMessage = ({ message, color }: FieldMessageProps) => {
+  return (
+    <Text color={color} size="xs">
+      {message}
+    </Text>
+  );
+};
+
+export default React.memo(FieldMessage);

--- a/src/components/common/Toast/ToastItem.tsx
+++ b/src/components/common/Toast/ToastItem.tsx
@@ -1,0 +1,88 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { Text } from '~/components/atom';
+import { useTimeout } from '~/hooks';
+import theme from '~/styles/theme';
+
+export interface Toast {
+  id: string;
+  message: string;
+  duration: number;
+}
+
+interface ToastItemProps {
+  toast: Toast;
+  onDone?: () => void;
+}
+
+const ToastItem = ({ toast, onDone }: ToastItemProps) => {
+  const { message, duration } = toast;
+  const [show, setShow] = useState(true); // animation을 위한 상태
+  useTimeout(() => {
+    setShow(false);
+    setTimeout(() => onDone && onDone(), 400);
+  }, duration);
+
+  return (
+    <Container style={{ opacity: show ? 1 : 0 }}>
+      <ProgressBar style={{ animationDuration: `${duration}ms` }} />
+      <Text>{message}</Text>
+    </Container>
+  );
+};
+
+export default ToastItem;
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  width: 300px;
+  height: 70px;
+  padding: 0 20px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 8px;
+  /* border-top-left-radius: 0;
+  border-top-right-radius: 0; */
+  border: 1px solid #ccc;
+  background-color: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+
+  opacity: 1;
+  transition: opacity 0.4s ease-out;
+  &:first-of-type {
+    animation: move 0.4s ease-out forwards;
+  }
+  &:not(:first-of-type) {
+    margin-top: 8px;
+  }
+  @keyframes move {
+    0% {
+      margin-top: -80px;
+    }
+    100% {
+      margin-top: 0;
+    }
+  }
+`;
+
+const ProgressBar = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 4px;
+  //background-color: ${theme.color.mainColor};
+  animation-name: progress;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+  @keyframes progress {
+    0% {
+      width: 0;
+    }
+    100% {
+      width: 100%;
+    }
+  }
+`;

--- a/src/components/common/Toast/ToastManager.tsx
+++ b/src/components/common/Toast/ToastManager.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+import { useCallback, useEffect, useState } from 'react';
+import ToastItem, { Toast } from './ToastItem';
+
+export type CreateToast = (message: string, duration: number) => void;
+
+interface ToastManagerProps {
+  bind: (createToast: CreateToast) => void;
+}
+
+const ToastManager = ({ bind }: ToastManagerProps) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const createToast = useCallback((message: string, duration: number) => {
+    const newToast = {
+      id: Date.now().toString(),
+      message,
+      duration
+    };
+    setToasts((oldToasts) => [...oldToasts, newToast]);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((oldToasts) => oldToasts.filter((toast) => toast.id !== id));
+  }, []);
+
+  useEffect(() => {
+    bind(createToast);
+  }, [bind, createToast]);
+
+  return (
+    <Container>
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDone={() => removeToast(toast.id)} />
+      ))}
+    </Container>
+  );
+};
+
+export default ToastManager;
+
+const Container = styled.div`
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  margin-left: -150px;
+  z-index: 1500;
+`;

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,0 +1,45 @@
+import ReactDOM from 'react-dom';
+import ToastManager, { CreateToast } from './ToastManager';
+
+const TOAST_PORTAL_ID = 'toast-portal';
+
+class Toast {
+  static instance: Toast;
+  private portalId = TOAST_PORTAL_ID;
+  private portal: HTMLElement | null = null;
+  private createToast: CreateToast | null = null;
+
+  constructor() {
+    if (Toast.instance) {
+      return Toast.instance;
+    }
+    Toast.instance = this;
+
+    if (typeof document !== 'undefined') {
+      const portalElement = document.getElementById(this.portalId);
+      if (portalElement) {
+        this.portal = portalElement;
+        return;
+      } else {
+        this.portal = document.createElement('div');
+        this.portal.id = this.portalId;
+        document.body.appendChild(this.portal);
+      }
+
+      ReactDOM.render(
+        <ToastManager
+          bind={(createToast) => {
+            this.createToast = createToast;
+          }}
+        />,
+        this.portal
+      );
+    }
+  }
+
+  show(message: string, duration = 2000) {
+    this.createToast!(message, duration);
+  }
+}
+
+export default new Toast();

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -13,3 +13,4 @@ export { default as ErrorMessage } from './Form/ErrorMessage';
 export { default as SearchInput } from './SearchInput';
 export { default as SelectRegion } from './SelectRegion';
 export { default as SelectTags } from './SelectTags';
+export { default as Toast } from './Toast';

--- a/src/components/domain/LoginForm/index.tsx
+++ b/src/components/domain/LoginForm/index.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
-import React, { useMemo } from 'react';
+import React, { KeyboardEvent, useMemo, useState } from 'react';
 import { useFormik } from 'formik';
 import { SchemaOf, object, string } from 'yup';
 import styled from '@emotion/styled';
 import theme from '~/styles/theme';
 import { PageContainer, Logo, Input, Label, Button, Text } from '~/components/atom';
-import { Form } from '~/components/common';
+import { ErrorMessage, Form } from '~/components/common';
 import { LoginValues } from '~/types';
 
 const LoginValidationSchema: SchemaOf<LoginValues> = object().shape({
@@ -24,6 +24,7 @@ interface LoginFormProps {
 }
 
 const LoginForm = ({ onSubmit: handleSubmitAction, errorMessage }: LoginFormProps) => {
+  const [capsLockWarning, setCapsLockWarning] = useState(false);
   const { values, handleChange, handleSubmit } = useFormik({
     initialValues,
     onSubmit: (data: LoginValues) => {
@@ -31,6 +32,10 @@ const LoginForm = ({ onSubmit: handleSubmitAction, errorMessage }: LoginFormProp
     },
     validationSchema: LoginValidationSchema
   });
+
+  const handleCheckCapsLock = (e: KeyboardEvent<HTMLInputElement>) => {
+    e.getModifierState('CapsLock') ? setCapsLockWarning(true) : setCapsLockWarning(false);
+  };
 
   const submittable = useMemo(() => {
     return !Object.values(values).every((value) => value.length > 0);
@@ -59,7 +64,9 @@ const LoginForm = ({ onSubmit: handleSubmitAction, errorMessage }: LoginFormProp
               required
               value={values.password}
               onChange={handleChange}
+              onKeyUp={handleCheckCapsLock}
             />
+            {capsLockWarning && <ErrorMessage message="CapsLock이 켜져있어요." />}
             <Text color="red">{errorMessage}</Text>
             <Button type="submit" disabled={submittable}>
               로그인

--- a/src/components/domain/SignupForm/Fields/BirthField.tsx
+++ b/src/components/domain/SignupForm/Fields/BirthField.tsx
@@ -20,6 +20,8 @@ const BirthField: React.FC<BirthFieldProps> = ({ value, onChange, errors }) => {
       <Label htmlFor="birth" text="생년월일" />
       <Input
         type="date"
+        min="1900-01-01"
+        max="2030-12-31"
         name="birth"
         placeholder="YYYY-MM-DD"
         required

--- a/src/components/domain/SignupForm/Fields/EmailField.tsx
+++ b/src/components/domain/SignupForm/Fields/EmailField.tsx
@@ -22,6 +22,7 @@ const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkD
     (e: ChangeEvent<HTMLInputElement>) => {
       checkDuplicate && checkDuplicate(false);
       onChange(e);
+      setError('');
     },
     [onChange, checkDuplicate]
   );
@@ -33,10 +34,10 @@ const EmailField: React.FC<EmailFieldProps> = ({ value, onChange, errors, checkD
   const handleClickDuplicate = async () => {
     try {
       await UserApi.emailCheck({ email: value });
-      window.alert(`${value}는 사용가능한 메일입니다.`);
+      setError('');
       checkDuplicate && checkDuplicate(true);
     } catch (e) {
-      window.alert('이미 존재하는 메일입니다.');
+      setError('이미 존재하는 메일입니다.');
     }
   };
 

--- a/src/components/domain/SignupForm/Fields/NicknameField.tsx
+++ b/src/components/domain/SignupForm/Fields/NicknameField.tsx
@@ -27,6 +27,7 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
     (e: ChangeEvent<HTMLInputElement>) => {
       checkDuplicate && checkDuplicate(false);
       onChange(e);
+      setError('');
     },
     [onChange, checkDuplicate]
   );
@@ -36,10 +37,10 @@ const NicknameField: React.FC<NicknameFieldProps> = ({
   const handleClickDuplicate = async () => {
     try {
       await UserApi.nicknameCheck({ nickname: value });
-      window.alert(`${value}는 사용가능한 닉네임입니다.`);
+      setError('');
       checkDuplicate && checkDuplicate(true);
     } catch (e) {
-      window.alert('이미 존재하는 닉네임입니다.');
+      setError('이미 존재하는 닉네임입니다.');
     }
   };
 

--- a/src/components/domain/SignupForm/Fields/PasswordCheckField.tsx
+++ b/src/components/domain/SignupForm/Fields/PasswordCheckField.tsx
@@ -22,7 +22,7 @@ const PasswordCheckField: React.FC<PasswordCheckFieldProps> = ({
   }, [errors]);
 
   useEffect(() => {
-    if (value && password !== value) {
+    if (value) {
       setError(errors);
     }
   }, [password, errors, value]);

--- a/src/components/domain/SignupForm/Fields/PasswordField.tsx
+++ b/src/components/domain/SignupForm/Fields/PasswordField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useState } from 'react';
+import React, { ChangeEvent, KeyboardEvent, useCallback, useState } from 'react';
 import { Input, Label, Text } from '~/components/atom';
 import { ErrorMessage, Field } from '~/components/common';
 
@@ -10,10 +10,15 @@ interface PasswordFieldProps {
 
 const PasswordField: React.FC<PasswordFieldProps> = ({ value, onChange, errors }) => {
   const [error, setError] = useState(errors);
+  const [capsLockWarning, setCapsLockWarning] = useState(false);
 
   const handleBlur = useCallback(() => {
     setError(errors);
   }, [errors]);
+
+  const handleCheckCapsLock = (e: KeyboardEvent<HTMLInputElement>) => {
+    e.getModifierState('CapsLock') ? setCapsLockWarning(true) : setCapsLockWarning(false);
+  };
 
   return (
     <Field>
@@ -29,7 +34,9 @@ const PasswordField: React.FC<PasswordFieldProps> = ({ value, onChange, errors }
         value={value}
         onChange={onChange}
         onBlur={handleBlur}
+        onKeyUp={handleCheckCapsLock}
       />
+      {capsLockWarning && <ErrorMessage message="CapsLock이 켜져있어요." />}
       {error && <ErrorMessage message={error} />}
     </Field>
   );

--- a/src/components/domain/SignupForm/index.tsx
+++ b/src/components/domain/SignupForm/index.tsx
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 import { useFormik } from 'formik';
 import React, { useMemo, useState } from 'react';
 import { Button, PageContainer, Title } from '~/components/atom';
-import { ErrorMessage, Form } from '~/components/common';
+import { Form } from '~/components/common';
+import FieldMessage from '~/components/common/Form/FieldMessage';
 import theme from '~/styles/theme';
 import { SignupValues } from '~/types';
 import {
@@ -66,10 +67,16 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               errors={errors.email}
               checkDuplicate={setIsCheckedDuplicateEmail}
             />
-            {errorMessage && !isCheckedDuplicateEmail && (
-              <DuplicatedError>
-                <ErrorMessage message="이메일 중복 검사를 해주세요." />
-              </DuplicatedError>
+            {isCheckedDuplicateEmail ? (
+              <Message>
+                <FieldMessage color="green" message="사용가능한 메일입니다." />
+              </Message>
+            ) : (
+              errorMessage && (
+                <Message>
+                  <FieldMessage color="red" message="이메일 중복 검사를 해주세요." />
+                </Message>
+              )
             )}
             <PasswordField
               value={values.password}
@@ -88,10 +95,16 @@ const SignupForm: React.FC<SignupFormProps> = ({ onSubmit: handleSubmitAction })
               errors={errors.nickname}
               checkDuplicate={setIsCheckedDuplicateNickname}
             />
-            {errorMessage && !isCheckedDuplicateNickname && (
-              <DuplicatedError>
-                <ErrorMessage message="닉네임 중복 검사를 해주세요." />
-              </DuplicatedError>
+            {isCheckedDuplicateNickname ? (
+              <Message>
+                <FieldMessage color="green" message="사용가능한 닉네임 입니다." />
+              </Message>
+            ) : (
+              errorMessage && (
+                <Message>
+                  <FieldMessage color="red" message="닉네임 중복 검사를 해주세요." />
+                </Message>
+              )
             )}
             <BirthField value={values.birth} onChange={handleChange} errors={errors.birth} />
             <SexField value={values.sex} onChange={handleChange} />
@@ -126,6 +139,6 @@ const Fields = styled.div`
   gap: 30px;
 `;
 
-const DuplicatedError = styled.div`
+const Message = styled.div`
   margin-top: -20px;
 `;

--- a/src/components/domain/UserInfo/EditForm/index.tsx
+++ b/src/components/domain/UserInfo/EditForm/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useFormik } from 'formik';
 import React, { ChangeEvent, useMemo, useState } from 'react';
 import { Button, Input, Text } from '~/components/atom';
-import { ErrorMessage } from '~/components/common';
+import FieldMessage from '~/components/common/Form/FieldMessage';
 import { UserApi } from '~/service';
 import { ValidationRules } from './rules';
 
@@ -52,7 +52,6 @@ const UserEditForm = ({ initialValues, onSubmit: onSubmitAction }: UserEditForm)
     try {
       const response = await UserApi.nicknameCheck({ nickname: values.nickname });
       if (response.status === 200) {
-        window.alert(`${values.nickname}는 사용가능한 닉네임입니다.`);
         setIsCheckedDuplicateNickname(true);
         setNicknameError('');
         return;
@@ -98,7 +97,13 @@ const UserEditForm = ({ initialValues, onSubmit: onSubmitAction }: UserEditForm)
           중복확인
         </Button>
       </Field>
-      <Error>{nicknameError && <ErrorMessage message={nicknameError} />}</Error>
+      <Message>
+        {initialValues.nickname === values.nickname ? null : isCheckedDuplicateNickname ? (
+          <FieldMessage color="green" message="사용가능한 닉네임입니다." />
+        ) : (
+          nicknameError && <FieldMessage color="red" message={nicknameError} />
+        )}
+      </Message>
       <Field>
         <label htmlFor="sex">성별</label>
         <Options role="sex" aria-labelledby="sex">
@@ -136,7 +141,7 @@ const UserEditForm = ({ initialValues, onSubmit: onSubmitAction }: UserEditForm)
           autoComplete="off"
         />
       </Field>
-      <Error>{errors.birth && <ErrorMessage message={errors.birth} />}</Error>
+      <Message>{errors.birth && <FieldMessage color="red" message={errors.birth} />}</Message>
       <Button
         type="submit"
         size="md"
@@ -180,6 +185,6 @@ const Options = styled.div`
   }
 `;
 
-const Error = styled.div`
+const Message = styled.div`
   margin-left: 160px;
 `;

--- a/src/components/domain/UserInfo/EditForm/index.tsx
+++ b/src/components/domain/UserInfo/EditForm/index.tsx
@@ -134,6 +134,8 @@ const UserEditForm = ({ initialValues, onSubmit: onSubmitAction }: UserEditForm)
         <Input
           style={{ width: '435px' }}
           type="date"
+          min="1900-01-01"
+          max="2030-12-31"
           name="birth"
           placeholder="YYYY-MM-DD"
           value={values.birth}

--- a/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
+++ b/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useFormik } from 'formik';
-import React, { useMemo, useState } from 'react';
+import React, { KeyboardEvent, useMemo, useState } from 'react';
 import { Button, Input } from '~/components/atom';
 import { ErrorMessage } from '~/components/common';
 import { UserPasswordFormValues } from '~/types/user';
@@ -17,6 +17,8 @@ interface PasswordChangeFormProps {
 }
 
 const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProps) => {
+  const [capsLockWarningOld, setCapsLockWarningOld] = useState(false);
+  const [capsLockWarningNew, setCapsLockWarningNew] = useState(false);
   const [passwordError, setPasswordError] = useState('');
   const { values, handleChange, handleSubmit, errors } = useFormik({
     initialValues,
@@ -25,6 +27,14 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
       onSubmitAction && onSubmitAction(data);
     }
   });
+
+  const handleCheckCapsLockOld = (e: KeyboardEvent<HTMLInputElement>) => {
+    e.getModifierState('CapsLock') ? setCapsLockWarningOld(true) : setCapsLockWarningOld(false);
+  };
+
+  const handleCheckCapsLockNew = (e: KeyboardEvent<HTMLInputElement>) => {
+    e.getModifierState('CapsLock') ? setCapsLockWarningNew(true) : setCapsLockWarningNew(false);
+  };
 
   const handleBlurPassword = () => {
     setPasswordError(errors.password || '');
@@ -48,9 +58,15 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
           placeholder="현재 비밀번호를 입력해주세요."
           value={values.oldPassword}
           onChange={handleChange}
+          onKeyUp={handleCheckCapsLockOld}
           required
         />
       </Field>
+      {capsLockWarningOld && (
+        <Error>
+          <ErrorMessage message="CapsLock이 켜져있어요." />
+        </Error>
+      )}
       <Field>
         <label htmlFor="password">새 비밀번호</label>
         <Input
@@ -61,8 +77,14 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
           value={values.password}
           onChange={handleChange}
           onBlur={handleBlurPassword}
+          onKeyUp={handleCheckCapsLockNew}
         />
       </Field>
+      {capsLockWarningNew && (
+        <Error>
+          <ErrorMessage message="CapsLock이 켜져있어요." />
+        </Error>
+      )}
       {passwordError && (
         <Error>
           <ErrorMessage message={passwordError} />

--- a/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
+++ b/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
@@ -30,7 +30,9 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
 
   const handleBlurPassword = () => {
     setPasswordError(errors.password || '');
-    values.passwordCheck && setPasswordCheckError(errors.passwordCheck || '');
+    if (values.passwordCheck) {
+      setPasswordCheckError(errors.passwordCheck || '');
+    }
   };
 
   const handleBlurPasswordCheck = () => {

--- a/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
+++ b/src/components/domain/UserInfo/PasswordChangeForm/index.tsx
@@ -18,8 +18,6 @@ interface PasswordChangeFormProps {
 
 const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProps) => {
   const [passwordError, setPasswordError] = useState('');
-  const [passwordCheckError, setPasswordCheckError] = useState('');
-
   const { values, handleChange, handleSubmit, errors } = useFormik({
     initialValues,
     validationSchema: ValidationRules,
@@ -30,13 +28,6 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
 
   const handleBlurPassword = () => {
     setPasswordError(errors.password || '');
-    if (values.passwordCheck) {
-      setPasswordCheckError(errors.passwordCheck || '');
-    }
-  };
-
-  const handleBlurPasswordCheck = () => {
-    setPasswordCheckError(errors.passwordCheck || '');
   };
 
   const submitButtonDisabled = useMemo(() => {
@@ -87,12 +78,11 @@ const PasswordChangeForm = ({ onSubmit: onSubmitAction }: PasswordChangeFormProp
           placeholder="새 비밀번호를 다시 입력해주세요."
           value={values.passwordCheck}
           onChange={handleChange}
-          onBlur={handleBlurPasswordCheck}
         />
       </Field>
-      {passwordCheckError && (
+      {values.passwordCheck && errors.passwordCheck && (
         <Error>
-          <ErrorMessage message={passwordCheckError} />
+          <ErrorMessage message={errors.passwordCheck} />
         </Error>
       )}
 

--- a/src/components/domain/UserInfo/ProfileCard/index.tsx
+++ b/src/components/domain/UserInfo/ProfileCard/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
 import { Icon, Link, Text, Title } from '~/components/atom';
 import Avatar from '~/components/atom/Avatar';
+import { Toast } from '~/components/common';
 import ImageUpload from '~/components/common/ImageUpload';
 import { useUser } from '~/hooks/useUser';
 import { UserApi } from '~/service';
@@ -40,6 +41,7 @@ const ProfileCard = ({
   const [previewImage, setPreviewImage] = useState(profileImage);
 
   const onLogout = () => {
+    Toast.show('로그아웃 되었습니다.', 1000);
     logout();
     router.push('/');
   };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useToggle } from './useToggle';
 export { default as useClickAway } from './useClickAway';
+export { default as useTimeout } from './useTimeout';

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const useTimeoutFn = (fn: () => void, ms: number) => {
+  const timeoutId = useRef<NodeJS.Timeout>();
+  const callback = useRef(fn);
+
+  useEffect(() => {
+    callback.current = fn;
+  }, [fn]);
+
+  const run = useCallback(() => {
+    timeoutId.current && clearTimeout(timeoutId.current);
+
+    timeoutId.current = setTimeout(() => {
+      callback.current();
+    }, ms);
+  }, [ms]);
+
+  const clear = useCallback(() => {
+    timeoutId.current && clearTimeout(timeoutId.current);
+  }, []);
+
+  useEffect(() => clear, [clear]);
+
+  return [run, clear];
+};
+
+const useTimeout = (fn: () => void, ms: number) => {
+  const [run, clear] = useTimeoutFn(fn, ms);
+
+  useEffect(() => {
+    run();
+    return clear;
+  }, [run, clear]);
+
+  return clear;
+};
+
+export default useTimeout;

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -14,7 +14,7 @@ const Signup: NextPage = () => {
     try {
       const response = await UserApi.signup(data);
       if (response.nickname === data.nickname) {
-        Toast.show(`${response.nickname}님 환영합니다!`, 1500);
+        Toast.show(`${response.nickname}님 환영합니다! 로그인해주세요.`, 1500);
         router.push('/login');
       }
     } catch (e) {

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { Toast } from '~/components/common';
 import { SignupForm } from '~/components/domain';
 import { UserApi } from '~/service';
 import { SignupValues } from '~/types';
@@ -13,9 +14,8 @@ const Signup: NextPage = () => {
     try {
       const response = await UserApi.signup(data);
       if (response.nickname === data.nickname) {
-        if (window.confirm(`${response.nickname}님 환영합니다! 로그인하러 갈까요?`)) {
-          router.push('/login');
-        }
+        Toast.show(`${response.nickname}님 환영합니다!`, 1500);
+        router.push('/login');
       }
     } catch (e) {
       console.error('회원가입 실패', e);

--- a/src/pages/userinfo/[id]/edit.tsx
+++ b/src/pages/userinfo/[id]/edit.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { PageContainer, Title } from '~/components/atom';
+import { Toast } from '~/components/common';
 import UserEditForm, { UserEditFormValues } from '~/components/domain/UserInfo/EditForm';
 import { useUser } from '~/hooks/useUser';
 import { UserApi } from '~/service';
@@ -22,6 +23,7 @@ const UserinfoEdit: NextPage = () => {
     const { nickname: prevNickname, birth: prevBirth, sex: prevSex } = initialValues;
     const { nickname, birth, sex } = data;
     if (prevNickname === nickname && prevBirth === birth && prevSex === sex) {
+      Toast.show('정보가 변경되었습니다.', 1000);
       router.push(`/userinfo/${userId}`);
       return;
     }
@@ -29,6 +31,7 @@ const UserinfoEdit: NextPage = () => {
     try {
       const response = await UserApi.edit({ nickname, birth, sex });
       if (response.status === 200) {
+        Toast.show('정보가 변경되었습니다.', 1000);
         router.push(`/userinfo/${userId}`);
       }
     } catch (e) {

--- a/src/pages/userinfo/[id]/password.tsx
+++ b/src/pages/userinfo/[id]/password.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import { PageContainer, Title } from '~/components/atom';
+import { Toast } from '~/components/common';
 import PasswordChangeForm from '~/components/domain/UserInfo/PasswordChangeForm';
 import { useUser } from '~/hooks/useUser';
 import { UserApi } from '~/service';
@@ -20,20 +21,19 @@ const UserinfoEdit: NextPage = () => {
     try {
       const response = await UserApi.changePassword({ oldPassword, newPassword });
       if (response.status === 200) {
-        // 다시 로그인 시키지 않고 유저 정보 페이지로 돌려보낸다.
-        window.alert('비밀번호 변경 성공!');
+        Toast.show('비밀번호가 변경되었습니다.', 1000);
         router.push(`/userinfo/${userId}`);
         return;
       }
     } catch (e: any) {
       const { response } = e;
       if (response.status === 400) {
-        window.alert('현재 비밀번호가 올바르지 않습니다.');
+        Toast.show('현재 비밀번호가 올바르지 않습니다.', 1000);
         return;
       }
 
       if (response.status === 409) {
-        window.alert('동일한 비밀번호로는 변경할 수 없어요.');
+        Toast.show('현재 비밀번호와 다른 비밀번호로 변경해주세요.', 1000);
         return;
       }
       console.error('비밀번호 수정 실패', e);

--- a/src/types/font.ts
+++ b/src/types/font.ts
@@ -37,7 +37,8 @@ export const FONT_COLORS = {
   blueGray: fontBlueGray,
   main: mainColor,
   red: fontRed,
-  recommend: recommendColor
+  recommend: recommendColor,
+  green: 'green'
 };
 
 export type FontColors = keyof typeof FONT_COLORS;


### PR DESCRIPTION
# ✅ 이슈번호
closes #13 

PR을 나누지 못해 죄송합니다...ㅜㅜ

# 📌 구현 내역
## 설명과 이미지

1. Toast 컴포넌트를 구현하여 `window.alert` 대신 사용했습니다. 아래는 현재 적용시켜놓은 곳입니다.
  - 회원가입 시) ~님 환영합니다! 로그인 해주세요.
  - 유저정보변경 시) 정보가 변경되었습니다.
  - 비밀번호 변경 시) 비밀번호가 변경되었습니다. // 현재 비밀번호가 올바르지 않습니다. // 현재 비밀번호와 다른 비밀번호로 변경해주세요.
  - 로그아웃 시) 로그아웃 되었습니다.
 
![toast](https://user-images.githubusercontent.com/64957267/184502436-6721f612-810a-46b1-8f98-abb6c5100977.gif)

2. Toast가 필요하지 않은 Form Field가 있다고 판단하여 아래는 Toast가 아닌 초록색 메세지를 보여주도록 개선했습니다.
  - 이메일 중복확인, 닉네임 중복확인 필드는 초록색 메세지를 보여준다) ~는 사용가능한 메일입니다. // 이미 존재하는 메일입니다.
<img width="691" alt="스크린샷 2022-08-14 오전 1 21 59" src="https://user-images.githubusercontent.com/64957267/184502477-1554070e-876d-4477-a97d-6e241e26e907.png">

3. 생년월일 필드에 최솟값(1900-01-01)과 최댓값(2030-12-31)을 적용하였습니다.

4. 비밀번호는 사용자에게 보여지지 않아서 CapsLock이 켜져있다는 것을 알려주면 좋을 것 같아 추가했습니다. (제가 비밀번호를 계속 틀렸는데 캡스락이 켜져있던 거였음...)

<img width="694" alt="스크린샷 2022-08-14 오전 1 22 49" src="https://user-images.githubusercontent.com/64957267/184502509-a71ea71b-0f60-4075-a841-ab850bccb668.png">

