### PR TITLE
feat: 해당 장소가 포함된 코스 페이지 구현

### DIFF
--- a/src/components/common/CourseList/CourseItem.tsx
+++ b/src/components/common/CourseList/CourseItem.tsx
@@ -62,7 +62,7 @@ const CourseItem = forwardRef(({ course, grid = 3, index }: CourseItemProps, ref
               {region} · {COURSE_COUNT}코스
             </Text>
             <Title level={3} size={18} ellipsis>
-              {title} - {id}
+              {title}
             </Title>
           </ThumbnailInfo>
         </ThumbnailWrapper>

--- a/src/components/common/Recommend/index.tsx
+++ b/src/components/common/Recommend/index.tsx
@@ -18,7 +18,7 @@ const Recommend = ({ active, ...props }: RecommendProps) => {
 
 export default Recommend;
 
-const { mainColor, borderDarkGray } = theme.color;
+const { mainColor, borderDarkGray, backgroundGray, borderGray } = theme.color;
 
 const IconContainer = styled.div<RecommendProps>`
   border: 1px solid ${({ active }) => (active ? mainColor : borderDarkGray)};

--- a/src/pages/course/search/[id].tsx
+++ b/src/pages/course/search/[id].tsx
@@ -25,7 +25,7 @@ interface Props {
   placeId: number;
 }
 
-const Course = ({ placeId }: Props) => {
+const CourseSearch = ({ placeId }: Props) => {
   const [courseList, setCourseList] = useState([]);
   const [page, setPage] = useState(0);
   const [lastTarget, setLastTarget] = useState(null);
@@ -81,7 +81,6 @@ const Course = ({ placeId }: Props) => {
   }, [lastTarget]);
 
   useEffect(() => {
-    console.log(page, 'page!'); // 처음 들어왔을 때 요청
     getCourseList({ page: 0, sorting: sorting });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -110,4 +109,4 @@ const Course = ({ placeId }: Props) => {
   );
 };
 
-export default Course;
+export default CourseSearch;

--- a/src/pages/place/[id].tsx
+++ b/src/pages/place/[id].tsx
@@ -123,7 +123,7 @@ const PlaceDetailByPostId = ({ place, placeId, courses }: Props) => {
             {/* 검색 결과로 이동 시켜야함 */}
             <RelevantHeader>
               <Title size="sm">이 장소가 포함된 코스</Title>
-              <Link href="/">
+              <Link href={`/course/search/${placeId}`}>
                 <Text color="gray">전체보기</Text>
               </Link>
             </RelevantHeader>

--- a/src/pages/place/search/[id].tsx
+++ b/src/pages/place/search/[id].tsx
@@ -1,0 +1,113 @@
+import type { NextPageContext } from 'next';
+import Head from 'next/head';
+import React, { useEffect, useState } from 'react';
+import { PageContainer } from '~/components/atom';
+import { CategoryTitle, CourseList, SortFilter } from '~/components/common';
+import { CourseApi } from '~/service';
+import { SortType } from '~/types/course';
+import { isNumber } from '~/utils/converter';
+
+export const getServerSideProps = async (context: NextPageContext) => {
+  const { query } = context;
+  const placeId = Number(query.id);
+  if (!isNumber(placeId)) {
+    return {
+      notFound: true
+    };
+  }
+
+  return {
+    props: { placeId }
+  };
+};
+
+interface Props {
+  placeId: number;
+}
+
+const Course = ({ placeId }: Props) => {
+  const [courseList, setCourseList] = useState([]);
+  const [page, setPage] = useState(0);
+  const [lastTarget, setLastTarget] = useState(null);
+  const [isLast, setIsLast] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [sorting, setSorting] = useState<SortType>('인기순');
+
+  const SIZE = 15;
+
+  const onIntersect: IntersectionObserverCallback = (entries, observer) => {
+    entries.forEach(async (entry) => {
+      if (entry.isIntersecting && !isLoading && !isLast) {
+        console.log('관찰');
+        getCourseList({ page: page + 1, sorting });
+        setPage((prev) => prev + 1);
+
+        observer.unobserve(entry.target);
+      }
+      if (isLast) {
+        observer.disconnect();
+      }
+    });
+  };
+
+  const getCourseList = async (filter: { page: number; sorting: SortType }) => {
+    setIsLoading(true);
+
+    const result = await CourseApi.search({ ...filter, placeId, size: SIZE });
+
+    if (page === 0) {
+      setCourseList(result.content);
+    } else {
+      setCourseList(courseList.concat(result.content));
+    }
+
+    if (result.last) {
+      console.log('마지막 페이지 입니다.');
+      setIsLast(true);
+    }
+
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    let observer: IntersectionObserver;
+    if (lastTarget) {
+      observer = new IntersectionObserver(onIntersect, { threshold: 0 });
+      observer.observe(lastTarget);
+    }
+    return () => observer && observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastTarget]);
+
+  useEffect(() => {
+    console.log(page, 'page!'); // 처음 들어왔을 때 요청
+    getCourseList({ page: 0, sorting: sorting });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSort = (value: SortType) => {
+    getCourseList({ page: 0, sorting: value });
+    setSorting(value);
+  };
+
+  return (
+    <React.Fragment>
+      <Head>
+        <title>우리의 여행코스 | 이곳저곳</title>
+        <meta name="description" content="our travel course" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main style={{ position: 'relative' }}>
+        <PageContainer>
+          <CategoryTitle name={`해당 장소가 포함된 코스 입니다.`} />
+
+          <SortFilter initialValue={sorting} onSort={handleSort} />
+          <CourseList courses={courseList} ref={setLastTarget} />
+        </PageContainer>
+      </main>
+    </React.Fragment>
+  );
+};
+
+export default Course;


### PR DESCRIPTION
# ✅ 이슈번호
closes #176

# 📌 구현 내역
## 해당 장소가 포함된 코스 페이지 구현
- 장소 상세페이지에서 해당 장소가 포함된 코스의 전체보기 클릭 시 이동되는 페이지를 구현했습니다.
- 검색결과 페이지와 코드가 비슷하지만 필터 내용이 없기 때문에 따로 구현을 했습니다.
- 추후 리팩토링 과정에서 합치는 방법을 고려해봐도 좋을 것 같습니다.
- 코스 검색 API로는 장소의 이름을 받을 수 없기 때문에 장소 상세조회 API를 추가했습니다.

## 이미지
![이장소가 포함된 코스](https://user-images.githubusercontent.com/81489300/184550537-5e4ae262-eb4a-4702-831f-19b2200da9f9.gif)

