### PR TITLE
hotfix: 장소 상세 페이지에서 카카오 장소 연결 안되는 현상 조치

### DIFF
--- a/src/pages/place/[id].tsx
+++ b/src/pages/place/[id].tsx
@@ -107,7 +107,7 @@ const PlaceDetailByPostId = ({ place, placeId, courses }: Props) => {
           </MapButton>
           {detailData && isOpenMap && (
             <PlaceMap
-              placeId={detailData.id}
+              placeId={Number(detailData.kakaoMapId)}
               placeType={detailData.category}
               placeName={detailData.name}
               center={{ lat: Number(detailData.latitude), lng: Number(detailData.longitude) }}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export type RegionAndAll = Region | '전체보기';
 
 export type PlacePost = {
   id: number;
+  kakaoMapId: string;
   name: string;
   addressName: string;
   roadAddressName: string;
@@ -53,6 +54,7 @@ export type PlacePost = {
   bookmarked: boolean;
   likeCount: number;
   usedCount: number;
+  comments: number;
 };
 
 export type Period = '당일' | '1~3일' | '4~7일' | '8~15일' | '15일이상';


### PR DESCRIPTION
# ✅ 이슈번호
closes #215 

# 📌 구현 내역
## 설명
장소 상세 페이지에서 카카오 장소 호출 시 잘못된 url을 호출하는 문제가 있어 수정하였습니다.

- before
![image](https://user-images.githubusercontent.com/15838144/184805030-0a7162ba-318c-49ae-86cc-4137d556e56d.png)


- after
![image](https://user-images.githubusercontent.com/15838144/184805053-8d6de495-b4a0-4418-9c37-fb863054e005.png)
