### PR TITLE
fix: 대댓글 프로필 이미지 현재 유저 프로필로 변경

### DIFF
--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -122,7 +122,7 @@ const CommentItem = ({
       {isOpenRecomment && (
         <CommentContainer style={{ paddingLeft: 50 }}>
           <Link href={`/userinfo/${comment.user.id}`}>
-            <Avatar size={66} src={comment.user.profileImage} />
+            <Avatar size={66} src={currentUser.user.profileImage} />
           </Link>
           <CommentEditor
             onSubmit={handleCreateRecomment}


### PR DESCRIPTION
# ✅ 이슈번호
closes #227 

# 📌 구현 내역
- 대댓글 프로필 부분 현재 게시글 작성자 profile로 되어있던 부분 현재 로그인 유저 profile로 변경하였습니다.
