### PR TITLE
feat: 페이지 이동 시 로딩 처리

### DIFF
--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -27,11 +27,11 @@ const Layout = ({ children, footer, full }: LayoutProps) => {
   }, [currentUser.accessToken]);
 
   return (
-    <div>
+    <>
       <Header full={full} isLoading={isLoading} />
       {children}
       {footer && <Footer />}
-    </div>
+    </>
   );
 };
 

--- a/src/components/common/Spinner/index.tsx
+++ b/src/components/common/Spinner/index.tsx
@@ -15,7 +15,8 @@ const { mainColor } = theme.color;
 
 const Loader = styled.div`
   width: 100%;
-  height: 100%;
+  height: calc(100% - 85px);
+  position: relative;
 
   @keyframes spinner {
     from {

--- a/src/components/common/Spinner/index.tsx
+++ b/src/components/common/Spinner/index.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import theme from '~/styles/theme';
+
+const Spinner = () => {
+  return (
+    <Loader>
+      <div className="spinner"></div>
+    </Loader>
+  );
+};
+
+export default Spinner;
+
+const { mainColor } = theme.color;
+
+const Loader = styled.div`
+  width: 100%;
+  height: 100%;
+
+  @keyframes spinner {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .spinner {
+    box-sizing: border-box;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 64px;
+    height: 64px;
+    margin-top: -32px;
+    margin-left: -32px;
+    border-radius: 50%;
+    border: 8px solid transparent;
+    border-top-color: ${mainColor};
+    border-bottom-color: ${mainColor};
+    animation: spinner 0.8s ease infinite;
+    z-index: 10;
+  }
+`;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useToggle } from './useToggle';
 export { default as useClickAway } from './useClickAway';
 export { default as useTimeout } from './useTimeout';
+export { default as useRouteChange } from './useRouteChange';

--- a/src/hooks/useRouteChange.ts
+++ b/src/hooks/useRouteChange.ts
@@ -1,0 +1,33 @@
+import { Router } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const useRouteChange = () => {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const start = (url: string, { shallow }: { shallow: boolean }) => {
+      if (!shallow) {
+        setLoading(true);
+      }
+    };
+    const end = () => {
+      setLoading(false);
+    };
+
+    Router.events.on('routeChangeStart', start);
+    Router.events.on('routeChangeComplete', end);
+    Router.events.on('routeChangeError', end);
+
+    return () => {
+      Router.events.off('routeChangeStart', start);
+      Router.events.off('routeChangeComplete', end);
+      Router.events.off('routeChangeError', end);
+    };
+  }, []);
+
+  return {
+    loading
+  };
+};
+
+export default useRouteChange;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,9 +3,12 @@ import '../styles/reset.css';
 import type { AppProps } from 'next/app';
 import type { NextPage } from 'next';
 import Layout from '~/components/common/Layout';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, useEffect, useState } from 'react';
 import { RecoilRoot } from 'recoil';
 import AppHead from '~/components/domain/AppHead';
+import { Router } from 'next/router';
+import Spinner from '~/components/common/Spinner';
+import { useRouteChange } from '~/hooks';
 
 export type NextPageWithLayout = NextPage & { getLayout?: (page: ReactElement) => ReactNode };
 type AppPropsWidthLayout = AppProps & { Component: NextPageWithLayout };
@@ -17,12 +20,14 @@ declare global {
 }
 
 function MyApp({ Component, pageProps }: AppPropsWidthLayout) {
+  const { loading } = useRouteChange();
+
   const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>);
 
   return (
     <>
       <AppHead />
-      <RecoilRoot>{getLayout(<Component {...pageProps} />)}</RecoilRoot>
+      <RecoilRoot>{getLayout(loading ? <Spinner /> : <Component {...pageProps} />)}</RecoilRoot>
     </>
   );
 }

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import type { NextPageContext } from 'next';
-import Head from 'next/head';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { PageContainer } from '~/components/atom';
@@ -23,7 +22,7 @@ import {
   correctedThemes,
   makeQueryString
 } from '~/utils/converter';
-import { useUser } from '~/hooks/useUser';
+import useDidMountEffect from '~/hooks/useDidMountEffect';
 
 export const getServerSideProps = async (context: NextPageContext) => {
   const { query } = context;
@@ -107,7 +106,8 @@ const Course = ({ query }: { query: Record<string, string> }) => {
       // `/course${makeQueryString(queries)}`,
       '/course',
       {
-        scroll: false
+        scroll: false,
+        shallow: true
       }
     );
   };

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -22,7 +22,6 @@ import {
   correctedThemes,
   makeQueryString
 } from '~/utils/converter';
-import useDidMountEffect from '~/hooks/useDidMountEffect';
 
 export const getServerSideProps = async (context: NextPageContext) => {
   const { query } = context;

--- a/src/pages/place/index.tsx
+++ b/src/pages/place/index.tsx
@@ -94,7 +94,8 @@ const Place = ({ query }: { query: Record<string, string> }) => {
       },
       `/place${makeQueryString(queries)}`,
       {
-        scroll: false
+        scroll: false,
+        shallow: true
       }
     );
   };

--- a/src/pages/userinfo/[id]/index.tsx
+++ b/src/pages/userinfo/[id]/index.tsx
@@ -57,7 +57,9 @@ const Userinfo: NextPage = () => {
   */
 
   const replaceRoute = (query: UserInfoTab) => {
-    router.replace({ pathname: '/userinfo/[id]', query: { tab: query } }, `/userinfo/${userId}`);
+    router.replace({ pathname: '/userinfo/[id]', query: { tab: query } }, `/userinfo/${userId}`, {
+      shallow: true
+    });
   };
 
   const onClickAction = async (value: UserInfoTab) => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,8 @@
 
 html,
 body {
+  width: 100%;
+  height: 100%;
   padding: 0;
   margin: 0;
 }
@@ -9,6 +11,11 @@ body {
 * {
   font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu,
     Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+#__next {
+  width: 100%;
+  height: 100%;
 }
 
 a {


### PR DESCRIPTION
# ✅ 이슈번호
closes #234 

# 📌 구현 내역

- 페이지 이동 시 spinner가 나타나도록 구현했습니다.
- route가 변경되면 spinner처리를 해두었는데 저희 페이지에서 router.replace 하는 부분도 routing으로 감지가 되어
replace 부분에 shallow 옵션을 추가했습니다.
![loading](https://user-images.githubusercontent.com/81489300/185763560-1f48f12c-d05e-4f84-8e20-85dc5714e99e.gif)

