### PR TITLE
refactor: 공통 컴포넌트 type 분리 및 내부 로직 수정

### DIFF
--- a/src/components/atom/Avatar/index.tsx
+++ b/src/components/atom/Avatar/index.tsx
@@ -11,7 +11,7 @@ interface AvatarProps {
 
 const defaultImage = '/assets/profile-default.jpg';
 
-const Avatar: React.FC<AvatarProps> = ({ src, size = 66, ...props }) => {
+const Avatar = ({ src, size = 55, ...props }: AvatarProps) => {
   const imageUrl = src || defaultImage;
   return (
     <ImageWrapper {...props} style={{ width: size, height: size }}>

--- a/src/components/atom/Button/index.tsx
+++ b/src/components/atom/Button/index.tsx
@@ -1,10 +1,6 @@
 import styled from '@emotion/styled';
 import { CSSProperties, MouseEvent, ReactNode } from 'react';
-import theme from '~/styles/theme';
-
-type ButtonTypes = 'primary' | 'borderPrimary' | 'tag' | 'darkGray' | 'borderNone' | 'gray';
-type ButtonSizes = 'sm' | 'md' | 'lg';
-
+import { buttonSize, ButtonSizes, buttonStyle, ButtonTypes } from './types';
 interface ButtonProps {
   type?: 'button' | 'submit';
   buttonType?: ButtonTypes;
@@ -49,90 +45,7 @@ const Button = ({
 
 export default Button;
 
-interface buttonStyleInterface {
-  [key: string]: string;
-}
-
-const { mainColor, fontDarkGray, borderDarkGray } = theme.color;
-
-const buttonStyle: buttonStyleInterface = {
-  primary: `
-    color: #fff;
-    background-color:${mainColor};
-
-    &:hover{
-      background-color:#438ce1;
-    }
-  `,
-  borderPrimary: `
-    color: ${mainColor};
-    background-color: #fff;
-    border: 1px solid ${mainColor};
-
-    &:hover {
-      background-color: #f6f9ff;
-    }
-  `,
-  tag: `
-    color: ${fontDarkGray};
-    border: 1px solid ${borderDarkGray};
-    box-shadow: 0px 2px 4px 1px rgb(0 0 0 / 5%);
-
-    &:hover {
-      background-color: #f4f8fb;
-      background-color: #f7f8f9;
- 
-    }
-  `,
-  darkGray: `
-    color: #fff;
-    background-color: #909090;
-
-  `,
-  gray: `
-    color: #262626;
-    background-color: #f1f1f1;
-
-    &:hover {
-      background-color:#e3e3e3;
-    }
-  `,
-  borderNone: `
-    color: ${mainColor};
-    background-color: #fff;
-
-    &:hover {
-      background-color: #f6f9ff;
-    }
-
-  `
-};
-
-const buttonSize: buttonStyleInterface = {
-  sm: `
-    padding: 10px 20px;
-    font-size: 18px;
-  `,
-  md: `
-    padding: 16px 22px;
-    font-size: 20px;
-  `,
-  lg: `
-    padding: 20px 45px;
-    font-size: 22px;
-  `
-};
-
-interface ButtonInterface {
-  buttonType?: string;
-  size?: string;
-  width?: number | string;
-  height?: number;
-  fontSize?: number;
-  disabled?: boolean;
-}
-
-const StyledButton = styled.button<ButtonInterface>`
+const StyledButton = styled.button<ButtonProps>`
   ${({ buttonType }) => buttonType && buttonStyle[buttonType]};
   ${({ size }) => size && buttonSize[size]};
 

--- a/src/components/atom/Button/types.ts
+++ b/src/components/atom/Button/types.ts
@@ -1,0 +1,83 @@
+import theme from '~/styles/theme';
+
+export type ButtonTypes = 'primary' | 'borderPrimary' | 'tag' | 'darkGray' | 'borderNone' | 'gray';
+export type ButtonSizes = 'sm' | 'md' | 'lg';
+
+export type ButtonStyleType = {
+  [key in ButtonTypes]: string;
+};
+
+export type ButtonSizeType = {
+  [key in ButtonSizes]: string;
+};
+
+const { mainColor, fontDarkGray, borderDarkGray } = theme.color;
+const { basicShadow } = theme.shadow;
+
+export const buttonStyle: ButtonStyleType = {
+  primary: `
+    color: #fff;
+    background-color:${mainColor};
+
+    &:hover{
+      background-color:#438ce1;
+    }
+  `,
+  borderPrimary: `
+    color: ${mainColor};
+    background-color: #fff;
+    border: 1px solid ${mainColor};
+
+    &:hover {
+      background-color: #f6f9ff;
+    }
+  `,
+  tag: `
+    color: ${fontDarkGray};
+    border: 1px solid ${borderDarkGray};
+    box-shadow: ${basicShadow};
+
+    &:hover {
+      background-color: #f4f8fb;
+      background-color: #f7f8f9;
+ 
+    }
+  `,
+  darkGray: `
+    color: #fff;
+    background-color: #909090;
+
+  `,
+  gray: `
+    color: #262626;
+    background-color: #f1f1f1;
+
+    &:hover {
+      background-color:#e3e3e3;
+    }
+  `,
+  borderNone: `
+    color: ${mainColor};
+    background-color: #fff;
+
+    &:hover {
+      background-color: #f6f9ff;
+    }
+
+  `
+};
+
+export const buttonSize: ButtonSizeType = {
+  sm: `
+    padding: 10px 20px;
+    font-size: 18px;
+  `,
+  md: `
+    padding: 16px 22px;
+    font-size: 20px;
+  `,
+  lg: `
+    padding: 20px 45px;
+    font-size: 22px;
+  `
+};

--- a/src/components/atom/Image/index.tsx
+++ b/src/components/atom/Image/index.tsx
@@ -7,7 +7,12 @@ interface ImageProps {
   cover?: boolean;
 }
 
-const Image = ({ width = '100%', height, cover, ...props }: ImageProps & NextImageProps) => {
+const Image = ({
+  width = '100%',
+  height = 'auto',
+  cover,
+  ...props
+}: ImageProps & NextImageProps) => {
   return (
     <ImageWrapper width={width} height={height}>
       <NextImage layout="fill" objectFit={cover ? 'cover' : 'contain'} {...props} />
@@ -20,6 +25,7 @@ export default Image;
 const ImageWrapper = styled.div<ImageProps>`
   width: ${({ width }) => (typeof width === 'number' ? width + 'px' : width)};
   height: ${({ height }) => (typeof height === 'number' ? height + 'px' : height)};
+  position: relative;
   & > span {
     position: unset !important;
     height: ${({ height }) => (typeof height === 'number' ? height + 'px' : height)} !important;

--- a/src/components/atom/Logo/index.tsx
+++ b/src/components/atom/Logo/index.tsx
@@ -1,5 +1,4 @@
-import styled from '@emotion/styled';
-import Image from 'next/image';
+import { Image } from '~/components/atom';
 
 interface LogoProps {
   width?: number;
@@ -7,17 +6,7 @@ interface LogoProps {
 }
 
 const Logo = ({ width = 100, height = 30 }: LogoProps) => {
-  return (
-    <ImageWrapper width={width} height={height}>
-      <Image src="/assets/logo.png" alt="logo" layout="fill" objectFit="contain" />
-    </ImageWrapper>
-  );
+  return <Image src="/assets/logo.png" alt="logo" width={width} height={height} />;
 };
 
 export default Logo;
-
-const ImageWrapper = styled.div<{ width: number; height: number }>`
-  position: relative;
-  width: ${({ width }) => width}px;
-  height: ${({ height }) => height}px;
-`;

--- a/src/components/atom/Text/index.tsx
+++ b/src/components/atom/Text/index.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import React, { CSSProperties, ReactNode } from 'react';
 import { FontColors, FontSizes } from '~/types/font';
 import { FONT_SIZES, FONT_COLORS } from '~/types/font';
@@ -32,7 +31,7 @@ const Text = ({
     fontSize: size && (typeof size === 'number' ? size + 'px' : FONT_SIZES[size] + 'px'),
     color: color && (FONT_COLORS[color] || color),
     fontWeight: fontWeight && fontWeight,
-    display: block ? 'block' : 'inline-block'
+    display: block || ellipsis ? 'block' : 'inline-block'
   };
 
   return (

--- a/src/components/atom/Title/index.tsx
+++ b/src/components/atom/Title/index.tsx
@@ -31,7 +31,7 @@ const Title: React.FC<TitleProps> = ({
   const fontStyle = {
     fontSize: size && (typeof size === 'number' ? size + 'px' : TITLE_SIZES[size] + 'px'),
     fontWeight: fontWeight && fontWeight,
-    display: block ? 'block' : 'inline-block',
+    display: block || ellipsis ? 'block' : 'inline-block',
     color: color && (FONT_COLORS[color] || color),
     lineHeight: 1.5
   };

--- a/src/components/atom/Title/index.tsx
+++ b/src/components/atom/Title/index.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { CSSProperties, ReactNode } from 'react';
 import { FontColors, TitleSizes } from '~/types/font';
 import { TITLE_SIZES, FONT_COLORS } from '~/utils/constants';
@@ -16,8 +15,6 @@ interface TitleProps {
 
 type tagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-let tag: tagType = 'h2'; // default
-
 const Title: React.FC<TitleProps> = ({
   size = 'sm',
   level = 2,
@@ -26,42 +23,24 @@ const Title: React.FC<TitleProps> = ({
   block,
   ellipsis,
   children,
+  style,
   ...props
 }) => {
-  tag = level ? (`h${level}` as tagType) : tag;
+  const Tag: tagType = `h${level}`;
+
+  const fontStyle = {
+    fontSize: size && (typeof size === 'number' ? size + 'px' : TITLE_SIZES[size] + 'px'),
+    fontWeight: fontWeight && fontWeight,
+    display: block ? 'block' : 'inline-block',
+    color: color && (FONT_COLORS[color] || color),
+    lineHeight: 1.5
+  };
 
   return (
-    <Styled
-      size={size}
-      fontWeight={fontWeight}
-      block={block}
-      color={color}
-      ellipsis={ellipsis}
-      {...props}
-    >
+    <Tag className={ellipsis ? 'ellipsis' : ''} style={{ ...fontStyle, ...style }} {...props}>
       {children}
-    </Styled>
+    </Tag>
   );
 };
 
 export default Title;
-
-const Styled = styled[tag]<Omit<TitleProps, 'children'>>`
-  line-height: 1.5;
-  font-size: ${({ size }) =>
-    size && (typeof size === 'number' ? size + 'px' : TITLE_SIZES[size] + 'px')};
-  font-weight: ${({ fontWeight }) => fontWeight && fontWeight};
-  display: ${({ block }) => (block ? 'block' : 'inline-block')};
-
-  color: ${({ color }) => color && (FONT_COLORS[color] || color)};
-
-  ${({ ellipsis }) =>
-    ellipsis &&
-    `
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `}
-  word-break: break-all;
-`;

--- a/src/components/common/ArrowTitle/index.tsx
+++ b/src/components/common/ArrowTitle/index.tsx
@@ -21,7 +21,7 @@ export default ArrowTitle;
 
 const Container = styled.div`
   margin-bottom: 30px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
 `;
 

--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -63,10 +63,10 @@ const CommentItem = ({
       <CommentContainer isRecomment={isRecomment}>
         {comment.createdAt ? (
           <Link href={`/userinfo/${comment.user.id}`}>
-            <Avatar size={66} src={comment.user.profileImage} />
+            <Avatar src={comment.user.profileImage} />
           </Link>
         ) : (
-          <Avatar size={66} src={comment.user.profileImage} />
+          <Avatar src={comment.user.profileImage} />
         )}
         {!isOpenEditor ? (
           <>
@@ -121,7 +121,7 @@ const CommentItem = ({
       {isOpenRecomment && (
         <CommentContainer style={{ paddingLeft: 50 }}>
           <Link href={`/userinfo/${comment.user.id}`}>
-            <Avatar size={66} src={currentUser.user.profileImage} />
+            <Avatar src={currentUser.user.profileImage} />
           </Link>
           <CommentEditor
             onSubmit={handleCreateRecomment}

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -50,7 +50,7 @@ const Header = ({ full, isLoading }: HeaderProps) => {
           <Buttons>
             {isLoggedIn && (
               <Link href={`/userinfo/${currentUser.user.id}`}>
-                <Avatar size={54} src={currentUser.user.profileImage} />
+                <Avatar src={currentUser.user.profileImage} />
               </Link>
             )}
           </Buttons>
@@ -97,7 +97,7 @@ const Header = ({ full, isLoading }: HeaderProps) => {
                 )}
                 {isLoggedIn && !isLoading && (
                   <Link href={`/userinfo/${currentUser.user.id}`}>
-                    <Avatar size={54} src={currentUser.user.profileImage} />
+                    <Avatar src={currentUser.user.profileImage} />
                   </Link>
                 )}
               </Buttons>

--- a/src/components/common/PlaceList/index.tsx
+++ b/src/components/common/PlaceList/index.tsx
@@ -36,7 +36,7 @@ PlaceList.displayName = 'PlaceList';
 
 export default PlaceList;
 
-const StyledPlaceList = styled.div`
+const StyledPlaceList = styled.ul`
   display: flex;
   flex-wrap: wrap;
   margin-right: -10px;

--- a/src/components/common/SliderContainer/index.tsx
+++ b/src/components/common/SliderContainer/index.tsx
@@ -1,14 +1,17 @@
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 import Slider from 'react-slick';
-import theme from '~/styles/theme';
+import { buttonStyle, buttonType } from './types';
 
 interface SliderContainerProps {
   children: ReactNode;
   dots?: boolean;
+  button?: buttonType;
 }
 
-const SliderContainer = ({ children, dots }: SliderContainerProps) => {
+const SliderContainer = ({ children, dots, button = 'normal' }: SliderContainerProps) => {
   const settings = {
     infinite: false,
     speed: 500,
@@ -16,14 +19,19 @@ const SliderContainer = ({ children, dots }: SliderContainerProps) => {
     slidesToScroll: 3,
     dots: dots
   };
-  return <StyledSlider {...settings}>{children}</StyledSlider>;
+  return (
+    <StyledSlider {...settings} button={button}>
+      {children}
+    </StyledSlider>
+  );
 };
 
 export default SliderContainer;
 
-const StyledSlider = styled(Slider)`
+const StyledSlider = styled(Slider)<SliderContainerProps>`
   margin-top: 24px;
-  height: 360px;
+
+  ${({ button }) => button && buttonStyle[button]}
 
   .slick-list {
     margin-left: -10px;
@@ -39,31 +47,17 @@ const StyledSlider = styled(Slider)`
     width: 50px;
     height: 50px;
     z-index: 100;
-    background-image: url('/assets/icons/thinArrow.svg');
-    background-size: 45px;
     background-repeat: no-repeat;
     background-position: center;
 
     &.slick-disabled {
       display: none !important;
     }
-    &:hover {
-      background-image: url('/assets/icons/thinArrow-active.svg');
-    }
-  }
-
-  .slick-prev {
-    left: -56px;
-    transform: translate(0, -50%) rotate(180deg);
   }
 
   .slick-next:before,
   .slick-prev:before {
     content: '';
-  }
-
-  .slick-next {
-    right: -56px;
   }
 
   .slick-dots {

--- a/src/components/common/SliderContainer/types.ts
+++ b/src/components/common/SliderContainer/types.ts
@@ -1,0 +1,46 @@
+import theme from '~/styles/theme';
+
+export type buttonType = 'normal' | 'circle';
+
+export const buttonStyle: { [key in buttonType]: string } = {
+  normal: `
+  .slick-prev,
+  .slick-next {
+    background-image: url('/assets/icons/thinArrow.svg');
+    background-size: 45px;
+
+    &:hover {
+      background-image: url('/assets/icons/thinArrow-active.svg');
+    }
+  }
+
+  .slick-prev {
+    left: -56px;
+    transform: translate(0, -50%) rotate(180deg);
+  }
+
+  .slick-next {
+    right: -56px;
+  }
+  `,
+  circle: `
+  .slick-prev,
+  .slick-next {
+    background-color: white;
+    border-radius: 50%;
+    border: 1px solid ${theme.color.borderDarkGray};
+    box-shadow: ${theme.shadow.basicShadow};
+
+    &:hover {
+      background-color: #f7f8f9;
+    }
+  }
+
+  .slick-next {
+    background-image: url('/assets/icons/arrow-right.svg');
+  }
+  .slick-prev {
+    background-image: url('/assets/icons/arrow-left.svg');
+  }
+  `
+};

--- a/src/components/common/Spinner/index.tsx
+++ b/src/components/common/Spinner/index.tsx
@@ -15,8 +15,9 @@ const { mainColor } = theme.color;
 
 const Loader = styled.div`
   width: 100%;
-  height: calc(100% - 85px);
-  position: relative;
+  height: calc(100vh - 85px);
+  position: fixed;
+  background-color: white;
 
   @keyframes spinner {
     from {

--- a/src/components/domain/CourseDetail/KakaoButton/index.tsx
+++ b/src/components/domain/CourseDetail/KakaoButton/index.tsx
@@ -7,7 +7,6 @@ const KakaoButton = () => {
   useEffect(() => {
     const kakao = window.Kakao;
     if (kakao && !kakao.isInitialized()) {
-      console.log('카카오실행');
       kakao.init(process.env.NEXT_PUBLIC_KAKAO_SHARE_KEY);
     }
   }, []);

--- a/src/components/domain/CourseSlider/index.tsx
+++ b/src/components/domain/CourseSlider/index.tsx
@@ -1,26 +1,15 @@
-import Slider from 'react-slick';
-import 'slick-carousel/slick/slick.css';
-import 'slick-carousel/slick/slick-theme.css';
 import styled from '@emotion/styled';
-import theme from '~/styles/theme';
 import CourseSliderItem from './CourseSliderItem';
 import { IPlace } from '~/types/place';
+import SliderContainer from '~/components/common/SliderContainer';
 
 interface CourseSliderProps {
   places?: IPlace[];
 }
 
 const CourseSlider = ({ places }: CourseSliderProps) => {
-  const settings = {
-    dots: true,
-    infinite: false,
-    speed: 500,
-    slidesToShow: 3,
-    slidesToScroll: 3
-  };
-
   return (
-    <StyledSlider {...settings}>
+    <StyledSlider button="circle">
       {places?.map((place, index) => (
         <CourseSliderItem
           key={place.id}
@@ -37,53 +26,9 @@ const CourseSlider = ({ places }: CourseSliderProps) => {
 
 export default CourseSlider;
 
-const { borderDarkGray } = theme.color;
-const { basicShadow } = theme.shadow;
-
-export const StyledSlider = styled(Slider)`
-  margin-top: 24px;
-
-  .slick-list {
-    margin-left: -10px;
-    margin-right: -10px;
-  }
-
+export const StyledSlider = styled(SliderContainer)`
   .slick-prev,
   .slick-next {
-    background-color: white;
-    border-radius: 50%;
-    border: 1px solid ${borderDarkGray};
-    width: 50px;
-    height: 50px;
-    z-index: 100;
-    background-repeat: no-repeat;
-    background-position: center;
-    box-shadow: ${basicShadow};
-    transition: all 0.1s;
-
-    &:hover {
-      background-color: #f7f8f9;
-    }
-
-    &.slick-disabled {
-      display: none !important;
-    }
-  }
-
-  .slick-next {
-    background-image: url('/assets/icons/arrow-right.svg');
-  }
-  .slick-prev {
-    background-image: url('/assets/icons/arrow-left.svg');
-  }
-
-  .slick-next:before,
-  .slick-prev:before {
-    content: '';
-  }
-
-  .slick-dots {
-    position: static;
-    margin-top: 20px;
+    top: calc(50% + 33px);
   }
 `;

--- a/src/components/domain/Place/RelevantCourses.tsx
+++ b/src/components/domain/Place/RelevantCourses.tsx
@@ -1,11 +1,10 @@
-import 'slick-carousel/slick/slick.css';
-import 'slick-carousel/slick/slick-theme.css';
 import CourseItem from '~/components/common/CourseList/CourseItem';
 import { ICourseItem } from '~/types/course';
 import SliderContainer from '~/components/common/SliderContainer';
 import { useState } from 'react';
 import ConfirmModal from '~/components/common/ConfirmModal';
 import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
 
 interface SliderProps {
   courses: ICourseItem[];
@@ -21,11 +20,11 @@ const RelevantCourses = ({ courses }: SliderProps) => {
 
   return (
     <>
-      <SliderContainer>
+      <StyledSlider>
         {courses.map((course) => (
           <CourseItem course={course} key={course.id} grid={1} onModal={setModalVisible} />
         ))}
-      </SliderContainer>
+      </StyledSlider>
       <ConfirmModal
         visible={modalVisible}
         onClose={() => setModalVisible(false)}
@@ -38,3 +37,7 @@ const RelevantCourses = ({ courses }: SliderProps) => {
 };
 
 export default RelevantCourses;
+
+const StyledSlider = styled(SliderContainer)`
+  height: 360px;
+`;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,7 +8,7 @@ class MainDocument extends Document {
 
   render() {
     return (
-      <Html>
+      <Html lang="ko">
         <Head />
         <script defer src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
         <body>

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -151,7 +151,7 @@ const CourseDetail = ({ course, courseId }: Props) => {
 
             <Profile>
               <Link href={`/userinfo/${detailData.userId}`}>
-                <Avatar size={55} src={detailData.profileImage} />
+                <Avatar src={detailData.profileImage} />
               </Link>
               <Text color="dark" fontWeight={500}>
                 {detailData.nickname}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,7 +82,12 @@ const HomePage = ({ places, courses }: Props) => {
       <main>
         <PageContainer>
           <SearchArea>
-            <Image width={550} src="/assets/search-img.png" alt="여행할 땐 이곳저곳" />
+            <Image
+              width={550}
+              src="/assets/search-img.png"
+              alt="여행할 땐 이곳저곳"
+              priority={true}
+            />
             <MainSearchForm onSubmit={handleSearch}>
               <SearchIcon name="searchBlue" size={30} />
               <MainSearchInput


### PR DESCRIPTION
# ✅ 이슈번호
closes #238 

# 📌 구현 내역

- Title 컴포넌트 level 적용 안되던 부분 수정했습니다.
- Button 컴포넌트 내부 코드가 길어져서 types로 분리했습니다.
- image 컴포넌트에 부모요소 relative속성이 없어서 warning 나타나던 부분 수정했습니다.
- 이전에 Slider컴포넌트 중복 코드 작성했던 부분 하나의 컴포넌트로 맞췄습니다.
- 페이지 로딩 시에 현재 scroll위치에 따라 spinner 위치가 달랐었는데 항상 화면 가운데에 나타나도록 수정했습니다.
- Lighthouse에서 제안한 내용에 따라 html에 lang 속성 추가하고 ul태그가 아닌 div로 감싸져 있던 부분 수정했습니다.

