### PR TITLE
feat: 페이지별 title/description 추가

### DIFF
--- a/src/components/common/PageHead/index.tsx
+++ b/src/components/common/PageHead/index.tsx
@@ -1,0 +1,25 @@
+import Head from 'next/head';
+
+interface PageHeadProps {
+  title: string;
+  description?: string;
+}
+
+const PageHead = ({ title, description }: PageHeadProps) => {
+  const metaTitle = `${title} | 이곳저곳`;
+
+  return (
+    <Head>
+      <title>{metaTitle}</title>
+      <meta property="og:title" content={metaTitle} />
+      {description && (
+        <>
+          <meta name="description" content={description} />
+          <meta property="og:description" content={description} />
+        </>
+      )}
+    </Head>
+  );
+};
+
+export default PageHead;

--- a/src/components/domain/AppHead/index.tsx
+++ b/src/components/domain/AppHead/index.tsx
@@ -5,8 +5,9 @@ const AppHead = () => {
     <Head>
       <title>우리의 여행코스 | 이곳저곳</title>
       <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <meta name="description" content="다양한 여행 코스 정보를 확인할 수 있는 이곳저곳!" />
       <meta property="og:type" content="website" />
-      <meta property="og:title" content="이곳저곳" />
+      <meta property="og:title" content="우리의 여행코스 | 이곳저곳" />
       <meta property="og:site_name" content="이곳저곳" />
       <meta property="og:url" content="https://team-09-p2p-fe.vercel.app/" />
       <meta property="og:image" content="/assets/images/og-image.png" />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,10 +3,9 @@ import '../styles/reset.css';
 import type { AppProps } from 'next/app';
 import type { NextPage } from 'next';
 import Layout from '~/components/common/Layout';
-import { ReactElement, ReactNode, useEffect, useState } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import AppHead from '~/components/domain/AppHead';
-import { Router } from 'next/router';
 import Spinner from '~/components/common/Spinner';
 import { useRouteChange } from '~/hooks';
 

--- a/src/pages/course/[id]/index.tsx
+++ b/src/pages/course/[id]/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import type { NextPage, NextPageContext } from 'next';
-import Head from 'next/head';
+import type { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { Link, PageContainer, Text, Title } from '~/components/atom';
@@ -8,6 +7,7 @@ import Avatar from '~/components/atom/Avatar';
 import Comment from '~/components/common/Comment';
 import ConfirmModal from '~/components/common/ConfirmModal';
 import DetailSidebar from '~/components/common/DetailSidebar';
+import PageHead from '~/components/common/PageHead';
 import CourseDetailList from '~/components/domain/CourseDetail/CourseDetailList';
 import CourseOverview from '~/components/domain/CourseDetail/CourseOverview';
 import CourseSlider from '~/components/domain/CourseSlider';
@@ -116,10 +116,8 @@ const CourseDetail = ({ course, courseId }: Props) => {
   }
 
   return (
-    <React.Fragment>
-      <Head>
-        <title>{course.title} | 이곳저곳</title>
-      </Head>
+    <>
+      <PageHead title={course.title} />
       <main>
         <PageContainer type="detail" style={{ position: 'relative' }}>
           <CourseDetailHeader>
@@ -199,7 +197,7 @@ const CourseDetail = ({ course, courseId }: Props) => {
           subMessage="게시물을 정말 삭제하시겠습니까?"
         />
       </main>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -22,6 +22,7 @@ import {
   correctedThemes,
   makeQueryString
 } from '~/utils/converter';
+import PageHead from '~/components/common/PageHead';
 
 export const getServerSideProps = async (context: NextPageContext) => {
   const { query } = context;
@@ -162,6 +163,7 @@ const Course = ({ query }: { query: Record<string, string> }) => {
 
   return (
     <React.Fragment>
+      <PageHead title="여행 코스" />
       <main style={{ position: 'relative' }}>
         <PageContainer>
           <CategoryTitle name="여행코스" />

--- a/src/pages/course/search/[id].tsx
+++ b/src/pages/course/search/[id].tsx
@@ -1,5 +1,4 @@
 import type { NextPageContext } from 'next';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { PageContainer } from '~/components/atom';
@@ -103,11 +102,6 @@ const CourseSearch = ({ placeId }: Props) => {
 
   return (
     <React.Fragment>
-      <Head>
-        <title>우리의 여행코스 | 이곳저곳</title>
-        <meta name="description" content="our travel course" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
       <main style={{ position: 'relative' }}>
         <PageContainer>
           <CategoryTitle name={`#${placeName}`} />

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -5,6 +5,7 @@ import { LoginForm } from '~/components/domain';
 import { LoginValues } from '~/types';
 import { useUser } from '~/hooks/useUser';
 import { useRouter } from 'next/router';
+import PageHead from '~/components/common/PageHead';
 
 const Login: NextPage = () => {
   const { login } = useUser();
@@ -22,9 +23,7 @@ const Login: NextPage = () => {
 
   return (
     <React.Fragment>
-      <Head>
-        <title>로그인 | 이곳저곳</title>
-      </Head>
+      <PageHead title="로그인" />
 
       <main>
         <LoginForm onSubmit={handleSubmit} errorMessage={errorMessage} />

--- a/src/pages/place/[id].tsx
+++ b/src/pages/place/[id].tsx
@@ -6,6 +6,7 @@ import { Button, Icon, Link, PageContainer, Text, Title } from '~/components/ato
 import Comment from '~/components/common/Comment';
 import DetailSidebar from '~/components/common/DetailSidebar';
 import ImageViewer from '~/components/common/ImageViewer';
+import PageHead from '~/components/common/PageHead';
 import PlaceMap from '~/components/domain/Map/PlaceMap';
 import RelevantCourses from '~/components/domain/Place/RelevantCourses';
 import { useUser } from '~/hooks/useUser';
@@ -82,9 +83,7 @@ const PlaceDetailByPostId = ({ place, placeId, courses }: Props) => {
 
   return (
     <React.Fragment>
-      <Head>
-        <title>{place.name} | 이곳저곳</title>
-      </Head>
+      <PageHead title={place.name} />
       <main>
         <Container type="detail" style={{ position: 'relative' }}>
           <PostHeader>

--- a/src/pages/place/index.tsx
+++ b/src/pages/place/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { PageContainer } from '~/components/atom';
 import { CategoryTitle, PlaceList, SelectRegion, SortFilter, Toast } from '~/components/common';
+import PageHead from '~/components/common/PageHead';
 import { useUser } from '~/hooks/useUser';
 import { PlaceApi } from '~/service';
 import { Period, Region, RegionAndAll } from '~/types';
@@ -143,6 +144,7 @@ const Place = ({ query }: { query: Record<string, string> }) => {
 
   return (
     <React.Fragment>
+      <PageHead title="추천 장소" />
       <main className="content">
         <PageContainer>
           <CategoryTitle name="추천장소" />

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import React, { useEffect, useState } from 'react';
 import { PageContainer, Title } from '~/components/atom';
 import { SelectTags, SelectRegion, CourseList, SortFilter } from '~/components/common';
+import PageHead from '~/components/common/PageHead';
 import { CourseApi } from '~/service';
 import { Period, RegionAndAll, SearchTagsValues, Spot, Theme } from '~/types';
 import { ICourseItem, SortType } from '~/types/course';
@@ -104,6 +105,7 @@ const SearchPage = ({ query }: { query: Record<string, string> }) => {
 
   return (
     <React.Fragment>
+      <PageHead title={query.keyword || ''} />
       <main>
         <PageContainer>
           <Title level={1} size="sm" style={{ margin: '30px 0' }}>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { Toast } from '~/components/common';
+import PageHead from '~/components/common/PageHead';
 import { SignupForm } from '~/components/domain';
 import { UserApi } from '~/service';
 import { SignupValues } from '~/types';
@@ -24,9 +25,7 @@ const Signup: NextPage = () => {
 
   return (
     <React.Fragment>
-      <Head>
-        <title>회원가입 | 이곳저곳</title>
-      </Head>
+      <PageHead title="회원가입" />
 
       <main>
         <SignupForm onSubmit={handleSubmit} />

--- a/src/pages/userinfo/[id]/index.tsx
+++ b/src/pages/userinfo/[id]/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import type { NextPage } from 'next';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { PageContainer } from '~/components/atom';
@@ -141,12 +140,6 @@ const Userinfo: NextPage = () => {
   }
   return (
     <React.Fragment>
-      <Head>
-        <title>우리의 여행코스 | 이곳저곳</title>
-        <meta name="description" content="our travel course" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-
       <main>
         <PageContainer>
           <Wrapper>


### PR DESCRIPTION
# ✅ 이슈번호
closes #207 

# 📌 구현 내역
## 페이지별 title/description 추가

- 사이트 전체의 head부분을 일괄로 처리했던 부분을 pageHead 컴포넌트를 생성하여
title 변경이 필요한 페이지에 적용하였습니다.
- next head의 경우 기본 mata태그인 title, description의 경우 중첩으로 작성 시 덮어쓰기가 되는데
og태그의 경우 중첩으로 작성 시 덮어쓰기가 아닌 추가가 됩니다.
![image](https://user-images.githubusercontent.com/81489300/187672683-d4c0ecdb-76a2-4359-9b87-b7bb90f9af6c.png)
- 해당 페이지 링크 공유 시 중첩으로 작성한 og:title이 적용되는지는 배포 후에 확인해봐야 할 것 같습니다.

## 유저 페이지 SSR적용
- meta title에 유저 nickname을 넣으려면 데이터를 미리 받아야 하기도 하고
처음 받아오는 데이터는 유저의 기본 정보만 담겨있기 때문에 문제가 없을 듯 하여 SSR을 적용했습니다.
- 뒤로가기 시 데이터 패칭이 되지 않아서 따로 처리하는 코드를 작성했습니다.