### PR TITLE
refactor: ReactDOM.render를 createRoot 메서드로 변경

### DIFF
--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import ToastManager, { CreateToast } from './ToastManager';
 
 const TOAST_PORTAL_ID = 'toast-portal';
@@ -28,13 +28,14 @@ class Toast {
         document.body.appendChild(this.portal);
       }
 
-      ReactDOM.render(
+      const root = createRoot(this.portal);
+
+      root.render(
         <ToastManager
           bind={(createToast) => {
             this.createToast = createToast;
           }}
-        />,
-        this.portal
+        />
       );
     }
   }


### PR DESCRIPTION
# ✅ 이슈번호
closes #251 

# 📌 구현 내역
## 설명

React17까지는 `ReactDOM.render`였지만 18부터 메서드가 지원되지 않게 되었습니다. 따라서 `createRoot` 메서드로 변경했습니다.
