### PR TITLE
refactor: Axios에서 500번대 에러는 캐치하는 로직 추가

### DIFF
--- a/src/service/core/Api.ts
+++ b/src/service/core/Api.ts
@@ -1,40 +1,16 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
-import TokenStorage from '~/utils/storage/TokenStorage';
+import { AxiosInstance } from 'axios';
+import { createInstance, auth, handleError, handleResponse } from './workers';
 
 export default class Api {
   private readonly API_END_POINT = process.env.NEXT_PUBLIC_API_END_POINT as string;
+  protected baseInstance: AxiosInstance;
+  protected authInstance: AxiosInstance;
 
-  private interceptors = (instance: AxiosInstance): AxiosInstance => {
-    instance.interceptors.request.use(
-      (config) => {
-        const token = TokenStorage.getToken();
-        config.headers = {
-          Authorization: token || ''
-        };
-        return config;
-      },
-      (error) => Promise.reject(error.response)
-    );
-    return instance;
-  };
+  constructor() {
+    const instance = createInstance(this.API_END_POINT);
+    instance.interceptors.response.use(handleResponse, handleError);
 
-  private createInstance = (url: string, config?: AxiosRequestConfig<any>): AxiosInstance => {
-    return axios.create({
-      baseURL: url,
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      ...config
-    });
-  };
-
-  private baseAPI = (url: string, config?: AxiosRequestConfig<any>): AxiosInstance => {
-    return this.createInstance(url, config);
-  };
-  private authAPI = (url: string, config?: AxiosRequestConfig<any>): AxiosInstance => {
-    return this.interceptors(this.createInstance(url, config));
-  };
-
-  protected baseInstance = this.baseAPI(this.API_END_POINT);
-  protected authInstance = this.authAPI(this.API_END_POINT);
+    this.baseInstance = instance;
+    this.authInstance = auth(instance);
+  }
 }

--- a/src/service/core/workers.ts
+++ b/src/service/core/workers.ts
@@ -1,0 +1,38 @@
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import TokenStorage from '~/utils/storage/TokenStorage';
+
+const createInstance = (url: string, config?: AxiosRequestConfig): AxiosInstance => {
+  return axios.create({
+    baseURL: url,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    ...config
+  });
+};
+
+const auth = (instance: AxiosInstance): AxiosInstance => {
+  instance.interceptors.request.use(
+    (config) => {
+      const token = TokenStorage.getToken();
+      config.headers = {
+        Authorization: token || ''
+      };
+      return config;
+    },
+    (error) => Promise.reject(error.response)
+  );
+  return instance;
+};
+
+const handleResponse = (res: AxiosResponse) => res;
+
+const handleError = (error: AxiosError) => {
+  if (error.response && error.response.status >= 500) {
+    window.alert('현재 서버에 문제가 있습니다.');
+    console.error(error);
+  }
+  return Promise.reject(error);
+};
+
+export { createInstance, auth, handleResponse, handleError };


### PR DESCRIPTION
# ✅ 이슈번호
closes #149 

# 📌 구현 내역
## 설명

Axios 객체에 에러를 캐치하는 함수를 구현하였습니다. 
1. 구현 과정에서 기존 core/Api 클래스 안에 있던 로직을 따로 분리했는데... 좋은건지 안좋은건지 잘 모르겠네영...ㅎㅎ
2. 에러코드에 대해서 캐치를 하는 이 부분에는 조금 연구가 많이 필요할 것 같다랄까... 제가 생각하는 제일 Best는 api를 사용하는 쪽에서 에러핸들링을 하지 않도록 하고 싶었는데(사실 이게 가능한건지, 가능하다면 좋은 방법은 어떤 것일지 고민이 많이 됐습니당..) 현재로서는 500번대 에러에 대해서 알림을 띄우는 것이 최선이었습니다 ㅜㅜ
3. 이번에 axios에 대해서 조금 더 공부하게 된 계기가 됐네요 ㅎㅎ 차차 공부해서 더 좋은 방법을 한번 찾아보려합니다!